### PR TITLE
Adding site-recovery manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -39,10 +39,10 @@ File Path | Manifest
 ------------- | ------------- 
 /boot/grub\*/grub.c\* | diagnostic, eg 
 /boot/grub\*/menu.lst | diagnostic, eg 
-/etc/HOSTNAME | agents, diagnostic, eg, lad 
-/etc/\*-release | agents, diagnostic, eg 
+/etc/HOSTNAME | agents, diagnostic, eg, lad, site-recovery 
+/etc/\*-release | agents, diagnostic, eg, site-recovery 
 /etc/fstab | diagnostic, eg, normal 
-/etc/hostname | agents, diagnostic, eg, genspec, lad 
+/etc/hostname | agents, diagnostic, eg, genspec, lad, site-recovery 
 /etc/network/interfaces | diagnostic, eg 
 /etc/network/interfaces.d/\*.cfg | diagnostic, eg 
 /etc/nsswitch.conf | diagnostic 
@@ -57,11 +57,11 @@ File Path | Manifest
 /etc/sysconfig/network/ifcfg-eth\* | diagnostic, eg 
 /etc/sysconfig/network/routes | diagnostic, eg 
 /etc/ufw/ufw.conf | diagnostic, eg 
-/etc/waagent.conf | agents, diagnostic, eg 
+/etc/waagent.conf | agents, diagnostic, eg, site-recovery 
 /var/lib/dhclient/dhclient-eth0.leases | diagnostic, eg 
 /var/lib/dhcp/dhclient.eth0.leases | diagnostic, eg 
 /var/lib/waagent/ExtensionsConfig.\*.xml | agents, diagnostic, lad 
-/var/lib/waagent/GoalState.\*.xml | agents, diagnostic 
+/var/lib/waagent/GoalState.\*.xml | agents, diagnostic, site-recovery 
 /var/lib/waagent/HostingEnvironmentConfig.xml | agents, diagnostic 
 /var/lib/waagent/ManagedIdentity-\*.json | diagnostic 
 /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml | agents, diagnostic 
@@ -70,24 +70,30 @@ File Path | Manifest
 /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/xmlCfg.xml | lad 
 /var/lib/waagent/Prod.\*.manifest.xml | agents, diagnostic 
 /var/lib/waagent/SharedConfig.xml | agents, diagnostic 
-/var/lib/waagent/\*.xml | agents 
+/var/lib/waagent/\*.xml | agents, site-recovery 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, eg, genspec 
+/var/log/AzureRcmCli.log | site-recovery 
 /var/log/auth\* | agents, diagnostic, eg, normal 
 /var/log/azure/Microsoft.\*LinuxDiagnostic/\*/\* | lad 
+/var/log/azure/\* | site-recovery 
 /var/log/azure/\*/\*/\* | agents, diagnostic 
 /var/log/boot\* | diagnostic, eg, normal 
 /var/log/cloud-init\* | diagnostic, eg, normal 
-/var/log/dmesg\* | agents, diagnostic, eg, normal 
+/var/log/dmesg\* | agents, diagnostic, eg, normal, site-recovery 
 /var/log/dpkg\* | diagnostic, eg, normal 
+/var/log/evtcollforw\*.log | site-recovery 
 /var/log/kern\* | diagnostic, eg, normal 
 /var/log/messages\* | diagnostic, eg, normal 
 /var/log/rsyslog\* | diagnostic, eg, lad, normal 
+/var/log/s2\*.log | site-recovery 
 /var/log/sa/sar\* | performance 
 /var/log/secure\* | diagnostic, eg, normal 
-/var/log/syslog\* | diagnostic, eg, lad, normal 
-/var/log/waagent\* | agents, diagnostic, eg, lad, normal 
+/var/log/svagents\*.log | site-recovery 
+/var/log/syslog\* | agents, diagnostic, eg, lad, normal, site-recovery 
+/var/log/ua_install.log | site-recovery 
+/var/log/waagent\* | agents, diagnostic, eg, lad, normal, site-recovery 
 /var/log/yum\* | diagnostic, eg, normal 
 /var/opt/microsoft/omsagent/LAD/log/\* | lad 
 ## windows 
@@ -156,13 +162,21 @@ File Path | Manifest
 /Packages/Plugins/\*/\*/Status/HeartBeat.Json | agents, diagnostic, normal 
 /Packages/Plugins/\*/\*/Status/\*.status | agents, diagnostic, normal 
 /Packages/Plugins/\*/\*/config.txt | agents, diagnostic, normal 
+/Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log | site-recovery 
+/Program Files (x86)/Microsoft Azure Site Recovery/agent/evtcollforw\*.log | site-recovery 
+/Program Files (x86)/Microsoft Azure Site Recovery/agent/s2\*.log | site-recovery 
+/Program Files (x86)/Microsoft Azure Site Recovery/agent/svagents\*.log | site-recovery 
 /Program Files/Microsoft SQL Server/\*/MSSQL/Log/\*.\* | sql-iaas 
+/ProgramData/ASRSetupLogs/ASRUnifiedAgentConfigurator.log | site-recovery 
+/ProgramData/ASRSetupLogs/ASRUnifiedAgentInstaller.log | site-recovery 
+/ProgramData/ASRSetupLogs/UnifiedAgentMSIInstall.log | site-recovery 
+/ProgramData/ASRSetupLogs/WrapperUnifiedAgent.log | site-recovery 
 /Windows/Inf/netcfg\*.\*etl | diagnostic, normal 
 /Windows/Inf/setupapi.dev.log | diagnostic, normal 
 /Windows/Panther/FastCleanup/setupact.log | diagnostic, eg, normal 
 /Windows/Panther/UnattendGC/setupact.log | diagnostic, eg, normal 
 /Windows/Panther/WaSetup.log | diagnostic, eg, normal 
-/Windows/Panther/WaSetup.xml | agents, diagnostic, eg, genspec, normal 
+/Windows/Panther/WaSetup.xml | agents, diagnostic, eg, genspec, normal, site-recovery 
 /Windows/Panther/setupact.log | diagnostic, eg, normal 
 /Windows/Panther/setuperr.log | diagnostic, eg, normal 
 /Windows/Panther/unattend.xml | diagnostic, eg, normal 
@@ -178,7 +192,7 @@ File Path | Manifest
 /Windows/System32/Sysprep/Sysprep_succeeded.tag | diagnostic, eg, normal 
 /Windows/System32/config/SOFTWARE | diagnostic 
 /Windows/System32/config/SYSTEM | diagnostic 
-/Windows/System32/winevt/Logs/Application.evtx | agents, diagnostic, eg, normal, sql-iaas 
+/Windows/System32/winevt/Logs/Application.evtx | agents, diagnostic, eg, normal, site-recovery, sql-iaas 
 /Windows/System32/winevt/Logs/Microsoft-ServiceFabric%4Admin.evtx | diagnostic, eg, normal 
 /Windows/System32/winevt/Logs/Microsoft-ServiceFabric%4Operational.evtx | diagnostic, eg, normal 
 /Windows/System32/winevt/Logs/Microsoft-ServiceFabric-Lease%4Admin.evtx | diagnostic, eg, normal 
@@ -227,8 +241,8 @@ File Path | Manifest
 /Windows/System32/winevt/Logs/MicrosoftAzureRecoveryServices-Replication.evtx | diagnostic, eg 
 /Windows/System32/winevt/Logs/Security.evtx | diagnostic, eg 
 /Windows/System32/winevt/Logs/Setup.evtx | diagnostic, eg 
-/Windows/System32/winevt/Logs/System.evtx | agents, diagnostic, eg, normal, sql-iaas 
-/Windows/System32/winevt/Logs/Windows Azure.evtx | agents, diagnostic, eg, normal 
+/Windows/System32/winevt/Logs/System.evtx | agents, diagnostic, eg, normal, site-recovery, sql-iaas 
+/Windows/System32/winevt/Logs/Windows Azure.evtx | agents, diagnostic, eg, normal, site-recovery 
 /Windows/debug/DCPROMO.LOG | diagnostic, eg, normal 
 /Windows/debug/NetSetup.LOG | diagnostic, eg, normal 
 /Windows/debug/PASSWD.LOG | diagnostic, eg, normal 
@@ -264,15 +278,16 @@ File Path | Manifest
 /WindowsAzure/Logs/Plugins/Microsoft.SqlServer.Management.SqlIaaSAgent/\*/CommandExec<br>ution\*.log | sql-iaas 
 /WindowsAzure/Logs/Plugins/Symantec.SymantecEndpointProtection/\*/sepManagedAzure.txt | agents, diagnostic, normal 
 /WindowsAzure/Logs/Plugins/TrendMicro.DeepSecurity.TrendMicroDSA/\*/\*.log | agents, diagnostic, normal 
+/WindowsAzure/Logs/Plugins/\* | site-recovery 
 /WindowsAzure/Logs/Plugins/\*/\*/CommandExecution.log | agents, diagnostic, eg, normal 
 /WindowsAzure/Logs/Plugins/\*/\*/Heartbeat.log | agents, diagnostic, eg, normal 
 /WindowsAzure/Logs/Plugins/\*/\*/Install.log | agents, diagnostic, eg, normal 
 /WindowsAzure/Logs/Plugins/\*/\*/Update.log | agents, diagnostic, eg, normal 
 /WindowsAzure/Logs/SqlServerLogs/\*.\* | sql-iaas 
-/WindowsAzure/Logs/Telemetry.log | agents, diagnostic, eg, normal 
-/WindowsAzure/Logs/TransparentInstaller.log | agents, diagnostic, eg, normal 
-/WindowsAzure/Logs/WaAppAgent.log | agents, diagnostic, eg, normal 
+/WindowsAzure/Logs/Telemetry.log | agents, diagnostic, eg, normal, site-recovery 
+/WindowsAzure/Logs/TransparentInstaller.log | agents, diagnostic, eg, normal, site-recovery 
+/WindowsAzure/Logs/WaAppAgent.log | agents, diagnostic, eg, normal, site-recovery 
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-08-16 13:20:41.743941`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-08-22 09:10:32.995431`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -77,6 +77,7 @@ agents | copy | /etc/waagent.conf
 agents | copy | /var/lib/waagent/\*.xml
 agents | copy | /var/log/waagent\*
 agents | copy | /var/log/dmesg\*
+agents | copy | /var/log/syslog\*
 agents | copy | /var/log/auth\*
 agents | copy | /var/log/azure/\*/\*/\*
 agents | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
@@ -205,6 +206,21 @@ normal | copy | /var/log/auth\*
 normal | copy | /var/log/secure\*
 performance | list | /var/log/sa
 performance | copy | /var/log/sa/sar\*
+site-recovery | copy | /etc/\*-release
+site-recovery | copy | /etc/HOSTNAME
+site-recovery | copy | /etc/hostname
+site-recovery | copy | /etc/waagent.conf
+site-recovery | copy | /var/lib/waagent/\*.xml
+site-recovery | copy | /var/log/waagent\*
+site-recovery | copy | /var/log/dmesg\*
+site-recovery | copy | /var/log/syslog\*
+site-recovery | copy | /var/log/azure/\*
+site-recovery | copy | /var/lib/waagent/GoalState.\*.xml
+site-recovery | copy | /var/log/ua_install.log
+site-recovery | copy | /var/log/AzureRcmCli.log
+site-recovery | copy | /var/log/svagents\*.log
+site-recovery | copy | /var/log/s2\*.log
+site-recovery | copy | /var/log/evtcollforw\*.log
 ## windows 
  Manifest | Operation | File Path 
  ------------- | ------------- | ------------- 
@@ -737,6 +753,22 @@ rdp-registry | registry query | HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall
 rdp-registry | registry query | HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-Compat-In-T<br>CP
 rdp-registry | registry query | HKLM\SOFTWARE\Policies\Microsoft\Windows\System\CleanupProfiles
 rdp-registry | registry query | HKLM\SOFTWARE\Microsoft\Shared Tools\MSConfig
+site-recovery | copy | /Windows/System32/winevt/Logs/System.evtx
+site-recovery | copy | /Windows/System32/winevt/Logs/Application.evtx
+site-recovery | copy | /Windows/System32/winevt/Logs/Windows Azure.evtx
+site-recovery | copy | /ProgramData/ASRSetupLogs/UnifiedAgentMSIInstall.log
+site-recovery | copy | /ProgramData/ASRSetupLogs/WrapperUnifiedAgent.log
+site-recovery | copy | /ProgramData/ASRSetupLogs/ASRUnifiedAgentInstaller.log
+site-recovery | copy | /ProgramData/ASRSetupLogs/ASRUnifiedAgentConfigurator.log
+site-recovery | copy | /Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log
+site-recovery | copy | /Program Files (x86)/Microsoft Azure Site Recovery/agent/svagents\*.log
+site-recovery | copy | /Program Files (x86)/Microsoft Azure Site Recovery/agent/s2\*.log
+site-recovery | copy | /Program Files (x86)/Microsoft Azure Site Recovery/agent/evtcollforw\*.log
+site-recovery | copy | /Windows/Panther/WaSetup.xml
+site-recovery | copy | /WindowsAzure/Logs/Telemetry.log
+site-recovery | copy | /WindowsAzure/Logs/TransparentInstaller.log
+site-recovery | copy | /WindowsAzure/Logs/WaAppAgent.log
+site-recovery | copy | /WindowsAzure/Logs/Plugins/\*
 sql-iaas | copy | /Windows/System32/winevt/Logs/System.evtx
 sql-iaas | copy | /Windows/System32/winevt/Logs/Application.evtx
 sql-iaas | copy | /Packages/Plugins/Microsoft.SqlServer.Management.SqlIaaSAgent/\*/config.txt
@@ -750,4 +782,4 @@ sql-iaas | copy | /WindowsAzure/Logs/Plugins/Microsoft.SqlServer.Management.SqlI
 sql-iaas | copy | /WindowsAzure/Logs/SqlServerLogs/\*.\*
 sql-iaas | copy | /Program Files/Microsoft SQL Server/\*/MSSQL/Log/\*.\*
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-08-16 13:20:41.743941`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-08-22 09:10:32.995431`*

--- a/pyServer/manifests/linux/agents
+++ b/pyServer/manifests/linux/agents
@@ -13,6 +13,7 @@ echo,
 echo,### Gathering Log Files ###
 copy,/var/log/waagent*
 copy,/var/log/dmesg*
+copy,/var/log/syslog*
 copy,/var/log/auth*
 copy,/var/log/azure/*/*/*
 echo,

--- a/pyServer/manifests/linux/site-recovery
+++ b/pyServer/manifests/linux/site-recovery
@@ -1,0 +1,23 @@
+echo,### Gathering Configuration Files ###
+copy,/etc/*-release
+copy,/etc/HOSTNAME
+copy,/etc/hostname
+copy,/etc/waagent.conf
+copy,/var/lib/waagent/*.xml
+echo,
+
+echo,### Gathering Log Files ###
+copy,/var/log/waagent*
+copy,/var/log/dmesg*
+copy,/var/log/syslog*
+copy,/var/log/azure/*
+
+echo,
+
+echo,### Gathering Extension Files ###
+copy,/var/lib/waagent/GoalState.*.xml
+copy,/var/log/ua_install.log
+copy,/var/log/AzureRcmCli.log
+copy,/var/log/svagents*.log
+copy,/var/log/s2*.log
+copy,/var/log/evtcollforw*.log

--- a/pyServer/manifests/windows/site-recovery
+++ b/pyServer/manifests/windows/site-recovery
@@ -1,0 +1,25 @@
+echo,### EXPERIMENTAL FEATURE ###
+echo,### Event Logs ###
+copy,/Windows/System32/winevt/Logs/System.evtx
+copy,/Windows/System32/winevt/Logs/Application.evtx
+copy,/Windows/System32/winevt/Logs/Windows Azure.evtx
+
+echo,### Additional Event Logs ###
+copy,/ProgramData/ASRSetupLogs/UnifiedAgentMSIInstall.log
+copy,/ProgramData/ASRSetupLogs/WrapperUnifiedAgent.log
+copy,/ProgramData/ASRSetupLogs/ASRUnifiedAgentInstaller.log
+copy,/ProgramData/ASRSetupLogs/ASRUnifiedAgentConfigurator.log
+copy,/Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log
+copy,/Program Files (x86)/Microsoft Azure Site Recovery/agent/svagents*.log
+copy,/Program Files (x86)/Microsoft Azure Site Recovery/agent/s2*.log
+copy,/Program Files (x86)/Microsoft Azure Site Recovery/agent/evtcollforw*.log
+
+echo,### Provisioning ###
+copy,/Windows/Panther/WaSetup.xml
+
+echo,### Guest Agent ###
+copy,/WindowsAzure/Logs/Telemetry.log
+copy,/WindowsAzure/Logs/TransparentInstaller.log
+copy,/WindowsAzure/Logs/WaAppAgent.log
+copy,/WindowsAzure/Logs/Plugins/*
+

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -102,6 +102,28 @@
       "os_product_name": "",
       "os_disk_configuration": "Encrypted",
       "files_present": [ ]
+    },
+    {
+      "title": "Site Recovery - Windows",
+      "description": "Test of the site-recovery manifest against a Windows VHD",
+      "vhd_relative_path": "/windows/asr-windows.vhd",
+      "manifest": "site-recovery",
+      "os": "windows",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "Standard",
+      "files_present": [ "/device_0/ProgramData/ASRSetupLogs/ASRUnifiedAgentInstaller.log", "/device_0/Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log", "/device_0/Windows/System32/winevt/Logs/System.evtx"]
+    },
+    {
+      "title": "Site Recovery - Linux",
+      "description": "Test of the site-recovery manifest against a Linux VHD",
+      "vhd_relative_path": "/linux/asr-linux.vhd",
+      "manifest": "site-recovery",
+      "os": "linux",
+      "os_distribution": "rhel",
+      "os_product_name": "Red Hat Enterprise Linux Server release 6.8 (Santiago)",
+      "os_disk_configuration": "Standard",
+      "files_present": [ "/device_0/var/log/waagent.log", "/device_0/var/log/AzureRcmCli.log", "/device_0/var/log/evtcollforw.log","device_0/var/log/azure/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/1.0.0.2/CommandExecution.log"]
     }
   ]
 }


### PR DESCRIPTION
PR is for the addition of the "site-recovery" manifest.  This will collect the files needed to troubleshoot issues with [Azure Site Recovery](https://azure.microsoft.com/en-us/services/site-recovery), as specified by members of the ASR engineering and support teams.