### PR TITLE
Collect /var/log/custom-script/handler.log

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -79,6 +79,7 @@ File Path | Manifest
 /var/log/azure/Microsoft.\*LinuxDiagnostic/\*/\* | lad 
 /var/log/azure/\* | site-recovery 
 /var/log/azure/\*/\*/\* | agents, diagnostic 
+/var/log/azure/custom-script/handler.log | agents, diagnostic 
 /var/log/boot\* | diagnostic, eg, normal 
 /var/log/cloud-init\* | diagnostic, eg, normal 
 /var/log/dmesg\* | agents, diagnostic, eg, normal, site-recovery 
@@ -290,4 +291,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-08-22 09:10:32.995431`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-11-11 23:58:17.716378`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -80,6 +80,7 @@ agents | copy | /var/log/dmesg\*
 agents | copy | /var/log/syslog\*
 agents | copy | /var/log/auth\*
 agents | copy | /var/log/azure/\*/\*/\*
+agents | copy | /var/log/azure/custom-script/handler.log
 agents | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
@@ -126,6 +127,7 @@ diagnostic | copy | /var/log/boot\*
 diagnostic | copy | /var/log/auth\*
 diagnostic | copy | /var/log/secure\*
 diagnostic | copy | /var/log/azure/\*/\*/\*
+diagnostic | copy | /var/log/azure/custom-script/handler.log
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
@@ -782,4 +784,4 @@ sql-iaas | copy | /WindowsAzure/Logs/Plugins/Microsoft.SqlServer.Management.SqlI
 sql-iaas | copy | /WindowsAzure/Logs/SqlServerLogs/\*.\*
 sql-iaas | copy | /Program Files/Microsoft SQL Server/\*/MSSQL/Log/\*.\*
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-08-22 09:10:32.995431`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2017-11-11 23:58:17.716378`*

--- a/pyServer/manifests/linux/agents
+++ b/pyServer/manifests/linux/agents
@@ -16,6 +16,7 @@ copy,/var/log/dmesg*
 copy,/var/log/syslog*
 copy,/var/log/auth*
 copy,/var/log/azure/*/*/*
+copy,/var/log/azure/custom-script/handler.log
 echo,
 
 echo,### Gathering Extension Files ###

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -42,6 +42,7 @@ copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*
 copy,/var/log/azure/*/*/*
+copy,/var/log/azure/custom-script/handler.log
 echo,
 
 echo,### Gathering Extension Files ###


### PR DESCRIPTION
CustomScript decided to go its own way, and this has defeated common
expectations. I will eventually fix this, but in the interim it would be
nice to collect this file. The Site-Recovery manifest can be used if
necessary to collect the appropriate data.