### PR TITLE
Improve telemetry for exceptions and handling of common errors

### DIFF
--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -368,18 +368,18 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
         except InvalidVhdNotFoundException as ex:
             unexpectedError = False
             telemetryException = ex
-            self.logException(ex, customProperties)
             failureStatusText = 'Vhd not found'
+            self.telemetryLogger.error(failureStatusText)  # don't raise exception            
         except InvalidStorageAccountException as ex:
             unexpectedError = False
             telemetryException = ex
-            self.logException(ex, customProperties)
             failureStatusText = 'Invalid storage account'
+            self.telemetryLogger.error(failureStatusText)  # don't raise exception  
         except InvalidSasException as ex:
             unexpectedError = False
             telemetryException = ex
-            self.logException(ex, customProperties)
             failureStatusText = 'Invalid SAS uri'
+            self.telemetryLogger.error(failureStatusText)  # don't raise exception  
         except ValueError as ex:
             unexpectedError = True
             telemetryException = ex

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -58,19 +58,16 @@ class GuestFishWrapper:
 
     def WriteToResultFileWithHeader(self, operationOutFile, headerString, data):
         operationOutFile.write(headerString + '\r\n')
-        if (isinstance(data, list)):
-            operationOutFile.write("\r\n".join(data))            
-        else:
-            operationOutFile.write(str(data))      
-        operationOutFile.write('\r\n')  
-        operationOutFile.write('\r\n')
-        operationOutFile.flush()
-    
+        self.WriteToResultFile(operationOutFile, data)
+
     def WriteToResultFile(self, operationOutFile, data):
         if (isinstance(data, list)):
-            operationOutFile.write("\r\n".join(data))            
+            tempStr = "\r\n".join(data)
         else:
-            operationOutFile.write(str(data))
+            tempStr = str(data)
+        operationOutFile.write(tempStr)
+        if len(tempStr) > 0:
+            self.rootLogger.info("OperationalLog: " + tempStr)  # ensure it is added to telemetry
         operationOutFile.write('\r\n') 
         operationOutFile.flush()
 
@@ -90,7 +87,7 @@ class GuestFishWrapper:
         osDistribution = guestfish.inspect_get_distro(device)
         osProductName = guestfish.inspect_get_product_name(device)
         osMountpoints = guestfish.inspect_get_mountpoints(device)
-        return (osType[0], osDistribution[0], osProductName[0], osMountpoints)        
+        return (osType[0], osDistribution[0], osProductName[0], osMountpoints)
 
     def CreateArchive(self, zipFilename, targetDir):
         with zipfile.ZipFile(zipFilename, "w", compression=zipfile.ZIP_DEFLATED) as zf:

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -124,6 +124,39 @@
       "os_product_name": "Red Hat Enterprise Linux Server release 6.8 (Santiago)",
       "os_disk_configuration": "Standard",
       "files_present": [ "/device_0/var/log/waagent.log", "/device_0/var/log/AzureRcmCli.log", "/device_0/var/log/evtcollforw.log","device_0/var/log/azure/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/1.0.0.2/CommandExecution.log"]
+    },
+    {
+      "title": "Invalid VHD path",
+      "description": "Test to ensure an invalid VHD path is handled properly",
+      "vhd_relative_path": "/linux/nosuch.vhd",
+      "manifest": "normal",
+      "os": "",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "",
+      "shouldFail" : true
+    },
+    {
+      "title": "Invalid SAS",
+      "description": "Test to ensure an invalid SAS uri is handled properly (performed in code)",
+      "vhd_relative_path": "/linux/UbuntuCore.vhd",
+      "manifest": "normal",
+      "os": "",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "",
+      "shouldFail" : true
+    },
+    {
+      "title": "Invalid storage account",
+      "description": "Test to ensure an invalid storage account is handled properly (performed in code)",
+      "vhd_relative_path": "/linux/UbuntuCore.vhd",
+      "manifest": "normal",
+      "os": "",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "",
+      "shouldFail" : true
     }
   ]
 }


### PR DESCRIPTION
- add logging of HOSTING_INSTANCE environment variable
- ensuring exceptions produced by the http handler have custom telemetry properties that aid in diagnosis
- revise error handling of failures to start() guestFish to diagnose 3 common error conditions by explicitly doing a http GET with SAS
- adjusting the exception handling in the http handler to not produce exception logging or consider the service as unhealthy due to these types of errors 
- adding tests for these 3 common error conditions
- correcting minor whitespace issues