### PR TITLE
Noticed that we weren't pulling CustomScriptExtension logs

### DIFF
--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -183,7 +183,8 @@ copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAge
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/*/*.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.ManagedIdentity.ManagedIdentityExtensionForWindows/*/RuntimeSettings/*.xml
 copy,/WindowsAzure/GuestAgent*/CommonAgentConfig.config
-
+copy,/WindowsAzure/Logs/Plugins/Microsoft.Compute.CustomScriptExtension/*/CustomScriptHandler*.log
+copy,/WindowsAzure/Logs/Plugins/Microsoft.Compute.CustomScriptExtension/*/CommandExecution*.log
  
 echo,### Gathering Disk Info ###
 diskinfo,


### PR DESCRIPTION
Noticed that we weren't pulling CustomScriptExtension logs - especially CustomScriptHandler.log... fixing that