### PR TITLE
remove agentsManifest from diagnostic

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -79,7 +79,7 @@ File Path | Manifest
 /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/status/\*.status | lad 
 /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/xmlCfg.xml | lad 
 /var/lib/waagent/SharedConfig.xml | diagnostic 
-/var/lib/waagent/\*.agentsManifest | agents, diagnostic 
+/var/lib/waagent/\*.agentsManifest | agents 
 /var/lib/waagent/\*.manifest.xml | diagnostic 
 /var/lib/waagent/\*.xml | agents, site-recovery, workloadbackup 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
@@ -327,4 +327,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-20 09:27:42.503971`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-20 22:50:22.511906`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -132,7 +132,6 @@ diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/\*.manifest.xml
-diagnostic | copy | /var/lib/waagent/\*.agentsManifest
 diagnostic | copy | /var/lib/waagent/SharedConfig.xml
 diagnostic | copy | /var/lib/waagent/ManagedIdentity-\*.json
 diagnostic | copy | /var/lib/waagent/error.json
@@ -867,4 +866,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-20 09:27:42.503971`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-20 22:50:22.511906`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -53,7 +53,6 @@ copy,/var/lib/waagent/*/config/*.settings
 copy,/var/lib/waagent/GoalState.*.xml
 copy,/var/lib/waagent/HostingEnvironmentConfig.xml
 copy,/var/lib/waagent/*.manifest.xml
-copy,/var/lib/waagent/*.agentsManifest
 copy,/var/lib/waagent/SharedConfig.xml
 copy,/var/lib/waagent/ManagedIdentity-*.json
 copy,/var/lib/waagent/error.json


### PR DESCRIPTION
agentsManifest is in the agents manifest, so no need to have it here too.