### PR TITLE
Disable fstab collection temporarily.

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -41,7 +41,7 @@ File Path | Manifest
 /boot/grub\*/menu.lst | diagnostic, eg 
 /etc/HOSTNAME | agents, diagnostic, eg, lad, site-recovery, workloadbackup 
 /etc/\*-release | agents, diagnostic, eg, site-recovery, workloadbackup 
-/etc/fstab | diagnostic, eg, normal 
+/etc/fstab | eg 
 /etc/hostname | agents, diagnostic, eg, genspec, lad, site-recovery, workloadbackup 
 /etc/network/interfaces | diagnostic, eg 
 /etc/network/interfaces.d/\*.cfg | diagnostic, eg 
@@ -327,4 +327,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-20 22:50:22.511906`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-29 23:08:37.775959`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -90,7 +90,6 @@ diagnostic | list | /var/log
 diagnostic | list | /var/lib/waagent
 diagnostic | list | /etc/udev/rules.d
 diagnostic | copy | /var/lib/waagent/provisioned
-diagnostic | copy | /etc/fstab
 diagnostic | copy | /etc/ssh/sshd_config
 diagnostic | copy | /boot/grub\*/grub.c\*
 diagnostic | copy | /boot/grub\*/menu.lst
@@ -191,7 +190,6 @@ lad | copy | /etc/opt/microsoft/omsagent/LAD/conf/omsagent.d/\*
 lad | copy | /var/opt/microsoft/omsagent/LAD/log/\*
 normal | list | /var/log
 normal | list | /etc/udev/rules.d
-normal | copy | /etc/fstab
 normal | copy | /etc/ssh/sshd_config
 normal | copy | /var/log/waagent\*
 normal | copy | /var/log/syslog\*
@@ -866,4 +864,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-20 22:50:22.511906`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-29 23:08:37.775959`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -5,7 +5,7 @@ ll,/etc/udev/rules.d
 
 echo,### Gathering Configuration Files ###
 copy,/var/lib/waagent/provisioned
-copy,/etc/fstab
+echo,### /etc/fstab collection temporarily disabled.
 copy,/etc/ssh/sshd_config
 copy,/boot/grub*/grub.c*
 copy,/boot/grub*/menu.lst

--- a/pyServer/manifests/linux/normal
+++ b/pyServer/manifests/linux/normal
@@ -3,7 +3,7 @@ ll,/var/log
 ll,/etc/udev/rules.d
 
 echo,### Gathering Configuration Files ###
-copy,/etc/fstab
+echo,### /etc/fstab collection temporarily disabled.
 copy,/etc/ssh/sshd_config
 echo,
 


### PR DESCRIPTION
Temporarily disable /etc/fstab data collection as they can contain AzureFileShare plaintext secrets. The collection of this file will be back once we have added redacting logic for the known issue.