### PR TITLE
Add wicked lease

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -60,8 +60,7 @@ File Path | Manifest
 /opt/msawb/bin/AzureWLBackupCommonManagementSettings.json | workloadbackup 
 /opt/msawb/bin/AzureWLBackupMonitoringSync_config.json | workloadbackup 
 /var/lib/dhclient/dhclient-eth0.leases | diagnostic, eg 
-/var/lib/dhcp/dhclient.eth0.leases | diagnostic, eg
-/var/lib/wicked/lease-eth0-dhcp-ipv4.xml | diagnostic, eg 
+/var/lib/dhcp/dhclient.eth0.leases | diagnostic, eg 
 /var/lib/waagent/ExtensionsConfig.\*.xml | diagnostic, lad 
 /var/lib/waagent/GoalState.\*.xml | diagnostic, site-recovery, workloadbackup 
 /var/lib/waagent/HostingEnvironmentConfig.xml | diagnostic 
@@ -85,6 +84,7 @@ File Path | Manifest
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/error.json | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, eg, genspec 
+/var/lib/wicked/lease-eth0-dhcp-ipv4.xml | diagnostic, eg 
 /var/log/AzureRcmCli.log | site-recovery 
 /var/log/auth\* | agents, diagnostic, eg, normal 
 /var/log/azure/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode/\*.\*/CommandExec<br>ution.log | servicefabric 
@@ -326,4 +326,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-30 02:25:37.061207`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-05-07 16:24:09.437875`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -60,7 +60,8 @@ File Path | Manifest
 /opt/msawb/bin/AzureWLBackupCommonManagementSettings.json | workloadbackup 
 /opt/msawb/bin/AzureWLBackupMonitoringSync_config.json | workloadbackup 
 /var/lib/dhclient/dhclient-eth0.leases | diagnostic, eg 
-/var/lib/dhcp/dhclient.eth0.leases | diagnostic, eg 
+/var/lib/dhcp/dhclient.eth0.leases | diagnostic, eg
+/var/lib/wicked/lease-eth0-dhcp-ipv4.xml | diagnostic, eg 
 /var/lib/waagent/ExtensionsConfig.\*.xml | diagnostic, lad 
 /var/lib/waagent/GoalState.\*.xml | diagnostic, site-recovery, workloadbackup 
 /var/lib/waagent/HostingEnvironmentConfig.xml | diagnostic 

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -109,6 +109,7 @@ diagnostic | copy | /etc/ufw/ufw.conf
 diagnostic | copy | /etc/waagent.conf
 diagnostic | copy | /var/lib/dhcp/dhclient.eth0.leases
 diagnostic | copy | /var/lib/dhclient/dhclient-eth0.leases
+diagnostic | copy | /var/lib/wicked/lease-eth0-dhcp-ipv4.xml
 diagnostic | copy | /var/log/waagent\*
 diagnostic | copy | /var/log/syslog\*
 diagnostic | copy | /var/log/rsyslog\*
@@ -156,6 +157,7 @@ eg | copy | /etc/ufw/ufw.conf
 eg | copy | /etc/waagent.conf
 eg | copy | /var/lib/dhcp/dhclient.eth0.leases
 eg | copy | /var/lib/dhclient/dhclient-eth0.leases
+eg | copy | /var/lib/wicked/lease-eth0-dhcp-ipv4.xml
 eg | copy | /var/log/waagent\*
 eg | copy | /var/log/syslog\*
 eg | copy | /var/log/rsyslog\*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -863,4 +863,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-03-30 02:25:37.061207`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-05-07 16:24:09.437875`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -27,6 +27,7 @@ copy,/etc/ufw/ufw.conf
 copy,/etc/waagent.conf
 copy,/var/lib/dhcp/dhclient.eth0.leases
 copy,/var/lib/dhclient/dhclient-eth0.leases
+copy,/var/lib/wicked/lease-eth0-dhcp-ipv4.xml
 echo,
 
 echo,### Gathering Log Files ###

--- a/pyServer/manifests/linux/eg
+++ b/pyServer/manifests/linux/eg
@@ -24,6 +24,7 @@ copy,/etc/ufw/ufw.conf
 copy,/etc/waagent.conf
 copy,/var/lib/dhcp/dhclient.eth0.leases
 copy,/var/lib/dhclient/dhclient-eth0.leases
+copy,/var/lib/wicked/lease-eth0-dhcp-ipv4.xml
 echo,
 
 echo,### Gathering Log Files ###


### PR DESCRIPTION
Add the dhcp lease file for the wicked network manager to the diagnostic and eg manifests.  Wicked is used by SLES 12.