### PR TITLE
Adding HOST information to logging and metrics

### DIFF
--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -310,13 +310,13 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
 
             sasKeyStr = str(postvars[b'saskey'][0], encoding='UTF-8')
             operationId, mode, modeMajorSkipTo, modeMinorSkipTo, storageAcctName, container_blob_name, storageUrl = self.ParseUrlArguments(self.path, sasKeyStr)                
-            self.telemetryLogger.info('Starting service request for <Operation Id=' + operationId + ', Mode=' + mode + ', Url=' + self.path + '>')
 
             # update the fields in the telemetry client
             for h in self.telemetryLogger.handlers:
                 if h.__class__.__name__ == 'LoggingHandler':
                     h.client.context.session.id = operationId                   
             self.telemetryClient.context.session.id = operationId
+            self.telemetryLogger.info('Starting service request for <Operation Id=' + operationId + ', Mode=' + mode + ', Url=' + self.path + '>')
 
             if ("error" in self.hostMetadata):
                 self.hostMetadata = getHostMetadata()
@@ -338,6 +338,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                     gfWrapper.start()
                     # Upload the ZIP file
                     if gfWrapper.outputFileName:    
+                        kpThread.avoidSendingKeepAlive = True  # stop KeepAlive while we send the zip to avoid corruption issue
                         outputFileName = gfWrapper.outputFileName            
                         outputFileSize = round(os.path.getsize(outputFileName) / 1024, 2)
                         self.telemetryLogger.info('Uploading: ' + outputFileName + ' (' + str(outputFileSize) + 'kb)')

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -370,16 +370,19 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
 
         except InvalidVhdNotFoundException as ex:
             unexpectedError = False
+            failureResultCode = 404
             telemetryException = ex
             failureStatusText = 'Vhd not found'
             self.telemetryLogger.error(failureStatusText)  # don't raise exception            
         except InvalidStorageAccountException as ex:
             unexpectedError = False
+            failureResultCode = 400
             telemetryException = ex
             failureStatusText = 'Invalid storage account'
             self.telemetryLogger.error(failureStatusText)  # don't raise exception  
         except InvalidSasException as ex:
             unexpectedError = False
+            failureResultCode = 400
             telemetryException = ex
             failureStatusText = 'Invalid SAS uri'
             self.telemetryLogger.error(failureStatusText)  # don't raise exception  

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -251,7 +251,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                         }
 
             roleinstance = "Unknown"
-            if (self.hostMetadata):
+            if ("name" in self.hostMetadata):
                 roleInstance = json.loads(self.hostMetadata)["name"]
             # Hack: we cram this data into a global context available in the Python AppInsights SDK 
             # which will be sent by the logger in a field that the Geneva connector will pickup, and we post-process during cook
@@ -342,7 +342,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                                 }
 
             roleinstance = "Unknown"
-            if (self.hostMetadata):
+            if ("name" in self.hostMetadata):
                 roleInstance = json.loads(self.hostMetadata)["name"]
             # Hack: we cram this data into a global context available in the Python AppInsights SDK 
             # which will be sent by the logger in a field that the Geneva connector will pickup, and we post-process during cook

--- a/pyServer/KeepAliveThread.py
+++ b/pyServer/KeepAliveThread.py
@@ -31,6 +31,7 @@ class KeepAliveThread(Thread):
         self.rootLogger = rootLogger
         self.guestfishPid = None
         self.wasTimeout = False
+        self.avoidSendingKeepAlive = False
         self.rootLogger.info('Starting KeepAliveWorkerThread for thread [' +
                      str(self.forThread) + '].')
 
@@ -47,10 +48,14 @@ class KeepAliveThread(Thread):
             totalWait = 0        
             while True:
                 if self.doWork:
-                    self.rootLogger.info(
-                        'Sending CONTINUE response to keep thread [' + str(self.forThread) + '] alive.')
-                    self.httpRequestHandler.send_response_only(100)
-                    self.httpRequestHandler.end_headers()
+                    if self.avoidSendingKeepAlive:
+                        self.rootLogger.info(
+                            'Avoiding sending CONTINUE while thread [' + str(self.forThread) + '] is sending zip...')
+                    else:
+                        self.rootLogger.info(
+                            'Sending CONTINUE response to keep thread [' + str(self.forThread) + '] alive.')
+                        self.httpRequestHandler.send_response_only(100)
+                        self.httpRequestHandler.end_headers()
                 else:
                     break
                 if self.exit_flag.wait(timeout=TIME_PERIOD):


### PR DESCRIPTION
- Add HOSTNAME environment variable to metrics emitted for alerting
- Adding HOSTNAME(~Role) and Metadata.Name(~RoleInstance) data to a global attribute available in the Python AppInsights SDK which is also picked up by the Geneva connector 
- Adding explicit catch for BrokenPipe exception
- Minor change to HTTP response code to more easily identify bad requests