### PR TITLE
Credential Scanner Integration + Re-adding fstab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get build-dep -y \
     libguestfs
 
+# Install Credential Scanner dependencies
+WORKDIR /
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list
+RUN apt-get update && apt-get install -y mono-complete
+
 # patched libguestfs
 WORKDIR /
 RUN git clone https://github.com/amitchat/libguestfs.git

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -9,6 +9,7 @@ File Path | Manifest
 /boot/loader.conf | diagnostic, normal 
 /etc/\*-release | agents 
 /etc/dhclient.conf | agents, diagnostic 
+/etc/fstab | diagnostic, normal 
 /etc/networks | diagnostic 
 /etc/nsswitch.conf | diagnostic 
 /etc/rc.conf | agents, diagnostic, genspec, normal 
@@ -40,6 +41,7 @@ File Path | Manifest
 /boot/grub\*/menu.lst | diagnostic, eg 
 /etc/HOSTNAME | agents, diagnostic, eg, lad, site-recovery, workloadbackup 
 /etc/\*-release | agents, diagnostic, eg, site-recovery, workloadbackup 
+/etc/fstab | diagnostic, eg, normal 
 /etc/hostname | agents, diagnostic, eg, genspec, lad, site-recovery, workloadbackup 
 /etc/network/interfaces | diagnostic, eg 
 /etc/network/interfaces.d/\*.cfg | diagnostic, eg 
@@ -326,4 +328,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-05-07 16:24:09.437875`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-06-08 18:37:59.895792`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -28,6 +28,7 @@ agents | copy | /var/lib/waagent/SharedConfig.xml
 diagnostic | list | /var/log
 diagnostic | list | /etc/rc.d
 diagnostic | copy | /var/lib/waagent/provisioned
+diagnostic | copy | /etc/fstab
 diagnostic | copy | /etc/ssh/sshd_config
 diagnostic | copy | /boot/loader.conf
 diagnostic | copy | /etc/dhclient.conf
@@ -56,6 +57,7 @@ genspec | copy | /var/lib/waagent/provisioned
 normal | list | /var/log
 normal | list | /etc/rc.d
 normal | copy | /etc/rc.conf
+normal | copy | /etc/fstab
 normal | copy | /etc/ssh/sshd_config
 normal | copy | /var/log/waagent\*
 normal | copy | /var/log/messages\*
@@ -88,6 +90,7 @@ diagnostic | list | /var/log
 diagnostic | list | /var/lib/waagent
 diagnostic | list | /etc/udev/rules.d
 diagnostic | copy | /var/lib/waagent/provisioned
+diagnostic | copy | /etc/fstab
 diagnostic | copy | /etc/ssh/sshd_config
 diagnostic | copy | /boot/grub\*/grub.c\*
 diagnostic | copy | /boot/grub\*/menu.lst
@@ -138,6 +141,7 @@ diagnostic | diskinfo |
 eg | list | /var/log
 eg | list | /etc/udev/rules.d
 eg | copy | /var/lib/waagent/provisioned
+eg | copy | /etc/fstab
 eg | copy | /boot/grub\*/grub.c\*
 eg | copy | /boot/grub\*/menu.lst
 eg | copy | /etc/\*-release
@@ -189,6 +193,7 @@ lad | copy | /etc/opt/microsoft/omsagent/LAD/conf/omsagent.d/\*
 lad | copy | /var/opt/microsoft/omsagent/LAD/log/\*
 normal | list | /var/log
 normal | list | /etc/udev/rules.d
+normal | copy | /etc/fstab
 normal | copy | /etc/ssh/sshd_config
 normal | copy | /var/log/waagent\*
 normal | copy | /var/log/syslog\*
@@ -863,4 +868,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-05-07 16:24:09.437875`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-06-08 18:37:59.895792`*

--- a/env.sh
+++ b/env.sh
@@ -17,6 +17,7 @@ SSL_PUBLIC_KEY="$SSL_PATH/azdis_public.crt"
 
 # Miscellaneous
 LOG_FILE="/var/log/azureDiskInspectSvc.log"
+CREDSCANSERVICEVOLUMENAME="CredScanSvc"
 
 # TODO: replace this with envionment specific AppInsights instrumentation key
 APPINSIGHTS_KEY='00000000-0000-0000-00000000000000000'

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -107,7 +107,7 @@ class GuestFishWrapper:
                         zf.write(path, os.path.relpath(path, base_path))        
         return zipFilename
 
-    def RunCredentialScanner(self, targetDir):
+    def RunCredentialScanner(self, targetDir, operationOutFile):
         if not os.path.exists("/CS_Latest/tools/CredentialScanner.exe"):
             strMsg = "Credential Scanner executable not found, skipping step."
             self.rootLogger.warning(strMsg)
@@ -147,7 +147,7 @@ class GuestFishWrapper:
             step_end_time = datetime.now()
             duration_seconds = (step_end_time - step_start_time).seconds
             strMsg = "Removed files containing secrets: " + ','.join(removed_files) + " [Operation duration: " + str(duration_seconds) + " seconds]"
-            self.rootLogger.info(strMsg)
+            self.WriteToResultFile(operationOutFile, strMsg)
 
     def execute(self, storageUrl):
         found_any_items= False
@@ -434,10 +434,10 @@ class GuestFishWrapper:
                 strLastGoodStep = str(lastGoodOperationMajorStep) + "." + str(lastGoodOperationMinorStep)
                 self.WriteToResultFile(operationOutFile, "\r\n##### WARNING: Partial results were collected as the operation was taking too long to complete. Consider retrying the operation specifying skip to step " + strLastGoodStep + " to continue gathering from last succesfully executed data collection step. #####")
 
-        self.rootLogger.info("Current working directory: " + str(os.getcwd()))
+            # Scan results for secrets
+            credScannerResults = self.RunCredentialScanner(requestDir, operationOutFile)
 
-        # Scan results for secrets
-        credScannerResults = self.RunCredentialScanner(requestDir)
+        self.rootLogger.info("Current working directory: " + str(os.getcwd()))     
 
         # Build the result output archive
         zipFileName = requestDir + ".zip"

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -115,9 +115,12 @@ class GuestFishWrapper:
 
         step_start_time = datetime.now()
         output_file = targetDir + "/credscan"
+        credscan_results_file = output_file + "-matches.tsv"
         try:
             # Run credential scanner
             bash_command = ["mono", "--runtime=v4.0", "/CS_Latest/tools/CredentialScanner.exe", "-I", targetDir, "-S", "/CS_Latest/tools/Searchers/buildsearchers.xml,/CS_Latest/tools/Searchers/diskinspectsearchers.xml", "-O", output_file, "-v"]
+            strMsg = "Running: " + ' '.join(bash_command)
+            self.WriteToResultFile(operationOutFile, strMsg)
             result = subprocess.run(bash_command, timeout=600)
         except subprocess.TimeoutExpired:
             strMsg = "Credential Scanner timed out after 10 min."
@@ -135,7 +138,7 @@ class GuestFishWrapper:
 
             # Remove files with secrets
             removed_files = []
-            with open(output_file + "-matches.tsv", encoding='utf-8', errors='replace') as tsv:
+            with open(credscan_results_file, encoding='utf-8', errors='replace') as tsv:
                 for line in csv.reader(tsv, delimiter='\t'):
                     source_file = line[1]
                     line_number = line[4]          

--- a/pyServer/manifests/freebsd/diagnostic
+++ b/pyServer/manifests/freebsd/diagnostic
@@ -4,7 +4,7 @@ ll,/etc/rc.d
 
 echo,### Gathering Configuration Files ###
 copy,/var/lib/waagent/provisioned
-echo,### /etc/fstab collection temporarily disabled.
+copy,/etc/fstab
 copy,/etc/ssh/sshd_config
 copy,/boot/loader.conf
 copy,/etc/dhclient.conf

--- a/pyServer/manifests/freebsd/normal
+++ b/pyServer/manifests/freebsd/normal
@@ -4,7 +4,7 @@ ll,/etc/rc.d
 
 echo,### Gathering Configuration Files ###
 copy,/etc/rc.conf
-echo,### /etc/fstab collection temporarily disabled.
+copy,/etc/fstab
 copy,/etc/ssh/sshd_config
 echo,
 

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -5,7 +5,7 @@ ll,/etc/udev/rules.d
 
 echo,### Gathering Configuration Files ###
 copy,/var/lib/waagent/provisioned
-echo,### /etc/fstab collection temporarily disabled.
+copy,/etc/fstab
 copy,/etc/ssh/sshd_config
 copy,/boot/grub*/grub.c*
 copy,/boot/grub*/menu.lst

--- a/pyServer/manifests/linux/eg
+++ b/pyServer/manifests/linux/eg
@@ -4,7 +4,7 @@ ll,/etc/udev/rules.d
 
 echo,### Gathering Configuration Files ###
 copy,/var/lib/waagent/provisioned
-echo,### /etc/fstab collection temporarily disabled.
+copy,/etc/fstab
 copy,/boot/grub*/grub.c*
 copy,/boot/grub*/menu.lst
 copy,/etc/*-release

--- a/pyServer/manifests/linux/normal
+++ b/pyServer/manifests/linux/normal
@@ -3,7 +3,7 @@ ll,/var/log
 ll,/etc/udev/rules.d
 
 echo,### Gathering Configuration Files ###
-echo,### /etc/fstab collection temporarily disabled.
+copy,/etc/fstab
 copy,/etc/ssh/sshd_config
 echo,
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,5 +21,12 @@ fi
 echo "Starting service..."
 docker create -v /etc/nginx/ssl --name $SERVICEVOLUMENAME ubuntu
 docker cp $SSL_PATH/. $SERVICEVOLUMENAME:/etc/nginx/ssl/.
-docker run -h $CONTAINERHOSTNAME --restart unless-stopped -t -d -p 8080:8080 --name $SERVICENAME --volumes-from $SERVICEVOLUMENAME -e APPINSIGHTS_KEY=$APPINSIGHTS_KEY -e CONTAINER_VERSION=$CONTAINERTAG -e affinity:image==$CONTAINERNAME $CONTAINERNAME
+
+if docker container inspect -f . $CREDSCANSERVICEVOLUMENAME; then
+  echo "Running with Credential Scanner"
+  docker run -h $CONTAINERHOSTNAME --restart unless-stopped -t -d -p 8080:8080 --name $SERVICENAME --volumes-from $SERVICEVOLUMENAME --volumes-from $CREDSCANSERVICEVOLUMENAME -e APPINSIGHTS_KEY=$APPINSIGHTS_KEY -e CONTAINER_VERSION=$CONTAINERTAG -e affinity:image==$CONTAINERNAME $CONTAINERNAME   
+else
+  docker run -h $CONTAINERHOSTNAME --restart unless-stopped -t -d -p 8080:8080 --name $SERVICENAME --volumes-from $SERVICEVOLUMENAME -e APPINSIGHTS_KEY=$APPINSIGHTS_KEY -e CONTAINER_VERSION=$CONTAINERTAG -e affinity:image==$CONTAINERNAME $CONTAINERNAME
+fi
+
 echo "Done."

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -11,7 +11,7 @@
       "os_distribution": "centos",
       "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
       "os_disk_configuration": "Standard",
-      "files_present": [ "device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
+      "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
     },
     {
       "title": "UbuntuCore (resilency)",
@@ -44,7 +44,7 @@
       "os_distribution": "freebsd",
       "os_product_name": "FreeBSD 10.3-RELEASE (GENERIC) #2 d912ed6(10.3.0_hyperv): Thu May 19 09:20:45 CST 2016",
       "os_disk_configuration": "Standard",
-      "files_present": [ "/device_0/etc/rc.conf", "device_0/etc/fstab", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
+      "files_present": [ "/device_0/etc/rc.conf", "/device_0/etc/fstab", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
     },
     {
       "title": "Windows genspec",

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -11,7 +11,7 @@
       "os_distribution": "centos",
       "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
       "os_disk_configuration": "Standard",
-      "files_present": [ "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
+      "files_present": [ "device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
     },
     {
       "title": "UbuntuCore (resilency)",
@@ -44,7 +44,7 @@
       "os_distribution": "freebsd",
       "os_product_name": "FreeBSD 10.3-RELEASE (GENERIC) #2 d912ed6(10.3.0_hyperv): Thu May 19 09:20:45 CST 2016",
       "os_disk_configuration": "Standard",
-      "files_present": [ "/device_0/etc/rc.conf", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
+      "files_present": [ "/device_0/etc/rc.conf", "device_0/etc/fstab", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
     },
     {
       "title": "Windows genspec",


### PR DESCRIPTION
- If Credential Scanner exists it is added to the docker container as a volume. Files are scanned and any files which include any secret (ex passwords/SAS keys) are deleted before being zipped.
- If Credential Scanner does not exist, disk inspection continues to run as before with an additional warning log.
- fstab has been added back. Initially removed [here](https://github.com/Azure/azure-diskinspect-service/commit/2753d0efdaa063aebe26a307fc7c434774931d21).
- Parse manifests have been updated.