### PR TITLE
Disk Inspect POST option for Cred Scan

### DIFF
--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -330,6 +330,12 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
             sasKeyStr = str(postvars[b'saskey'][0], encoding='UTF-8')
             operationId, mode, modeMajorSkipTo, modeMinorSkipTo, storageAcctName, container_blob_name, storageUrl = self.ParseUrlArguments(self.path, sasKeyStr)                
 
+            if b'credscan' in postvars:
+                credscanStr = str(postvars[b'credscan'][0], encoding='UTF-8')
+                runWithCredscan = (credscanStr == "true")
+            else:
+                runWithCredscan = False
+
             # update the fields in the telemetry client
             for h in self.telemetryLogger.handlers:
                 if h.__class__.__name__ == 'LoggingHandler':
@@ -358,7 +364,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
 
             # Invoke LibGuestFS Wrapper for prorcessing
             with KeepAliveThread(self.telemetryLogger, self, threading.current_thread().getName()) as kpThread:
-                with GuestFishWrapper(self.telemetryLogger, self, storageUrl, OUTPUTDIRNAME, operationId, mode, modeMajorSkipTo, modeMinorSkipTo, kpThread) as gfWrapper:
+                with GuestFishWrapper(self.telemetryLogger, self, storageUrl, OUTPUTDIRNAME, operationId, mode, modeMajorSkipTo, modeMinorSkipTo, kpThread, runWithCredscan) as gfWrapper:
                     gfWrapper.start()
                     # Upload the ZIP file
                     if gfWrapper.outputFileName:    

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -28,7 +28,7 @@ class GuestFishWrapper:
     kpThread = None
     osType = None
 
-    def __init__(self, rootLogger, handler, storageUrl, outputDirName, operationId, mode, modeMajorSkipTo, modeMinorSkipTo, kpThread):
+    def __init__(self, rootLogger, handler, storageUrl, outputDirName, operationId, mode, modeMajorSkipTo, modeMinorSkipTo, kpThread, runWithCredscan):
         self.environment = None
         self.httpRequestHandler = handler
         self.storageUrl = storageUrl
@@ -39,6 +39,7 @@ class GuestFishWrapper:
         self.modeMajorSkipTo = modeMajorSkipTo
         self.modeMinorSkipTo = modeMinorSkipTo
         self.kpThread = kpThread
+        self.runWithCredscan = runWithCredscan
         self.osType = "unknown"
         self.operationOutFilename = self.outputDirName + os.sep + 'results.txt'
         self.registryFilename= self.outputDirName + os.sep + 'registry.json'
@@ -528,7 +529,8 @@ class GuestFishWrapper:
                 self.WriteToResultFile(operationOutFile, "\r\n##### WARNING: Partial results were collected as the operation was taking too long to complete. Consider retrying the operation specifying skip to step " + strLastGoodStep + " to continue gathering from last succesfully executed data collection step. #####")
 
             # Scan results for secrets
-            credScannerResults = self.RunCredentialScanner(requestDir, operationOutFile)
+            if self.runWithCredscan:
+                self.RunCredentialScanner(requestDir, operationOutFile)
 
         self.rootLogger.info("Current working directory: " + str(os.getcwd()))     
 

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -189,7 +189,8 @@ class GuestFishWrapper:
                     strMsg = "CredentialScanner: Returned exit code {}".format(exit_code)
                     self.rootLogger.warning(strMsg)
 
-        # Remove files with secrets
+        # Remove found secrets from files
+        redacted_file_secrets = {}
         removed_file_secrets = {}
         with open(credscan_results_file, encoding='utf-8', errors='replace') as tsv:
             # Skip the first header line
@@ -198,10 +199,12 @@ class GuestFishWrapper:
                 source_file = line[1]
                 secret_found = line[2]
                 line_number = line[4]
+                is_redacted = False
 
                 # Remove secret - delete line for small files, entire file for large files
                 if os.path.isfile(source_file):
                     if os.path.getsize(filepath) < 1000000:
+                        is_redacted = True
                         with open(source_file, "r+") as f:
                             lines = f.readlines()
                             f.seek(0)
@@ -212,31 +215,40 @@ class GuestFishWrapper:
                                     f.write("***REDACTED***")
                             f.truncate()
                     else:
-                        print("WZ - removing large file")
                         os.remove(source_file)
 
                 # Strip out the common target dir for logging
                 relative_source_file = source_file.replace(targetDir + "/", "")
                 # Store additional details for logging
-                if relative_source_file not in removed_file_secrets:
-                    removed_file_secrets[relative_source_file] = defaultdict(int)
-                removed_file_secrets[relative_source_file][secret_found] += 1
+                if is_redacted:
+                    if relative_source_file not in redacted_file_secrets:
+                        redacted_file_secrets[relative_source_file] = defaultdict(int)
+                    redacted_file_secrets[relative_source_file][secret_found] += 1
+                else:
+                    if relative_source_file not in removed_file_secrets:
+                        removed_file_secrets[relative_source_file] = defaultdict(int)
+                    removed_file_secrets[relative_source_file][secret_found] += 1
 
+        num_secret_files = len(redacted_file_secrets.keys()) + len(removed_file_secrets.keys())
         num_removed_files = len(removed_file_secrets.keys())
 
         # No errors, include file removal in duration
         step_end_time = datetime.now()
         duration_seconds = (step_end_time - step_start_time).seconds
 
-        strMsg = "CredentialScanner: Statistics - No. Scanned Files: {}, Scanned Directory Size: {}, Operation duration: {} seconds, No. Removed: {}, Removed File List: [{}]".format(scanned_files_count, scanned_directory_size, duration_seconds, num_removed_files, ', '.join(removed_file_secrets.keys()))
+        strMsg = "CredentialScanner: Statistics - No. Scanned Files: {}, Scanned Directory Size: {}, Operation duration: {} seconds, No. Files Containing Secrets: {}, No. Files Removed: {}, Redacted File List: [{}], Removed File List: [{}]".format(scanned_files_count, scanned_directory_size, duration_seconds, num_secret_files, num_removed_files, ', '.join(redacted_file_secrets.keys()), ', '.join(removed_file_secrets.keys()))
         if num_removed_files > 0:
             # Only write to file if files have been removed
             self.WriteToResultFile(operationOutFile, strMsg)
 
             # Detailed output on secrets found
+            for redacted_file, secret_dict in redacted_file_secrets.items():
+                secrests_string = ["{} {}".format(secret, count) for secret, count in secret_dict.items()]
+                strMsg = "CredentialScanner: Detailed - Redacted File: {}, Secrets: [{}]".format(removed_file, ', '.join(secrets_string))
+                self.rootLogger.info(strMsg)
             for removed_file, secret_dict in removed_file_secrets.items():
                 secrets_string = ["{} {}".format(secret, count) for secret, count in secret_dict.items()]
-                strMsg = "CredentialScanner: Detailed - File: {}, Secrets: [{}]".format(removed_file, ', '.join(secrets_string))
+                strMsg = "CredentialScanner: Detailed - Removed File: {}, Secrets: [{}]".format(removed_file, ', '.join(secrets_string))
                 self.rootLogger.info(strMsg)
         else:
             self.rootLogger.info(strMsg)

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -198,9 +198,21 @@ class GuestFishWrapper:
                 secret_found = line[2]
                 line_number = line[4]
 
-                # Remove file
+                # Remove secret - delete line for small files, entire file for large files
                 if os.path.isfile(source_file):
-                    os.remove(source_file)
+                    if os.path.getsize(filepath) < 1000000:
+                        with open(source_file, "r+") as f:
+                            lines = f.readlines()
+                            f.seek(0)
+                            for i, line in enumerate(lines):
+                                if (i+1) != int(line_number):
+                                    f.write(line)
+                                else:
+                                    f.write("***REDACTED***")
+                            f.truncate()
+                    else:
+                        print("WZ - removing large file")
+                        os.remove(source_file)
 
                 # Strip out the common target dir for logging
                 relative_source_file = source_file.replace(targetDir + "/", "")


### PR DESCRIPTION
- Added POST parameter for credscan: `-d "credscan=true"` will run disk inspect with credscan, false or non-existent option will run disk inspect without credscan.
- Modified credential scanner to redact lines containing secrets in files < 1MB. Larger files will be removed as previously. Added logging to differentiate between files which got removed and files which had secrets redacted.