### PR TITLE
Parameterizing KeepAliveThread MaxTimeout

### DIFF
--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -20,6 +20,7 @@ from applicationinsights.logging import LoggingHandler
 import json
 
 OUTPUTDIRNAME = '/output'
+DEFAULT_TIMEOUT_IN_MINS = 19
 
 """
 Helper to print progress
@@ -341,9 +342,9 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                 timeoutInMinsStr = str(postvars[b'timeout'][0], encoding='UTF-8')
                 timeoutInMins = int(timeoutInMinsStr)
             else:
-                timeoutInMins = 19
+                timeoutInMins = DEFAULT_TIMEOUT_IN_MINS
 
-            self.telemetryLogger.info('Using timeout value=' + str(timeoutInMins))
+            self.telemetryLogger.info('Using timeout value: ' + str(timeoutInMins)+ ' min(s)')
 
             # update the fields in the telemetry client
             for h in self.telemetryLogger.handlers:

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -346,7 +346,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
 
             if b'timeout' in postvars:
                 timeoutInputStr = str(postvars[b'timeout'][0], encoding='UTF-8')
-                if timeoutInputStr.isdecimal() and int(timeoutInputStr) > 0 and int(timeoutInputStr) < 720 :
+                if timeoutInputStr.isdecimal() and int(timeoutInputStr) > 0 and int(timeoutInputStr) < 360 :
                     timeoutInMinsStr = timeoutInputStr
                 else:
                     self.telemetryLogger.info('WARNING: Received timeout override is invalid: {0}. Default will be used.'.format(timeoutInMinsStr))

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -342,11 +342,16 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
             else:
                 runWithCredscan = False
 
+            timeoutInMinsStr = str(DEFAULT_TIMEOUT_IN_MINS)
+
             if b'timeout' in postvars:
-                timeoutInMinsStr = str(postvars[b'timeout'][0], encoding='UTF-8')
-                timeoutInMins = int(timeoutInMinsStr)
-            else:
-                timeoutInMins = DEFAULT_TIMEOUT_IN_MINS
+                timeoutInputStr = str(postvars[b'timeout'][0], encoding='UTF-8')
+                if timeoutInputStr.isdecimal() and int(timeoutInputStr) > 0 and int(timeoutInputStr) < 720 :
+                    timeoutInMinsStr = timeoutInputStr
+                else:
+                    self.telemetryLogger.info('WARNING: Received timeout override is invalid: {0}. Default will be used.'.format(timeoutInMinsStr))
+
+            timeoutInMins = int(timeoutInMinsStr)
 
             self.telemetryLogger.info('Using timeout value: ' + str(timeoutInMins)+ ' min(s)')
 

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -65,6 +65,10 @@ def getContainerId():
     longContainerId = subprocess.check_output(['basename', line])
     return longContainerId.decode('utf-8')[0:12]
 
+
+class ResponseHeaderMetadata:
+    KEEPALIVETHREAD_TIMEOUT_IN_MINS = "KeepAliveThread-Timeout-In-Mins"
+
 """
 Threading server to handle multiple web requests.
 """
@@ -382,6 +386,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                         outputFileName = gfWrapper.outputFileName            
                         outputFileSize = round(os.path.getsize(outputFileName) / 1024, 2)
                         self.telemetryLogger.info('Uploading: ' + outputFileName + ' (' + str(outputFileSize) + 'kb)')
+                        gfWrapper.metadata_pairs[ResponseHeaderMetadata.KEEPALIVETHREAD_TIMEOUT_IN_MINS] = timeoutInMins
                         self.uploadFile(gfWrapper.metadata_pairs, outputFileName, kpThread.wasTimeout, gfWrapper.osType)
                         self.telemetryLogger.info('Upload completed.')
 

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -346,7 +346,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
 
             if b'timeout' in postvars:
                 timeoutInputStr = str(postvars[b'timeout'][0], encoding='UTF-8')
-                if timeoutInputStr.isdecimal() and int(timeoutInputStr) > 0 and int(timeoutInputStr) < 360 :
+                if timeoutInputStr.isdecimal() and int(timeoutInputStr) > 0 and int(timeoutInputStr) < 120 :
                     timeoutInMinsStr = timeoutInputStr
                 else:
                     self.telemetryLogger.info('WARNING: Received timeout override is invalid: {0}. Default will be used.'.format(timeoutInMinsStr))

--- a/pyServer/KeepAliveThread.py
+++ b/pyServer/KeepAliveThread.py
@@ -6,7 +6,6 @@ import threading
 from threading import Thread
 
 TIME_PERIOD = 60
-MAX_TIMEOUT = TIME_PERIOD * 19
 
 """
 Helper KeepAlive worker thread that attempts to
@@ -21,8 +20,9 @@ class KeepAliveThread(Thread):
     forThread = None
     guestfishPid = None
     wasTimeout = False
+    maxTimeout = 0
 
-    def __init__(self, rootLogger, handler, threadId):
+    def __init__(self, rootLogger, handler, threadId, timeoutInMins):
         Thread.__init__(self)
         self.httpRequestHandler = handler
         self.doWork = True
@@ -33,8 +33,9 @@ class KeepAliveThread(Thread):
         self.credscanPid = None
         self.wasTimeout = False
         self.avoidSendingKeepAlive = False
-        self.rootLogger.info('Starting KeepAliveWorkerThread for thread [' +
-                     str(self.forThread) + '].')
+        self.rootLogger.info('Starting KeepAliveWorkerThread for thread [' + str(self.forThread) + '].')
+        self.maxTimeout = TIME_PERIOD * timeoutInMins
+        self.rootLogger.info('KeepAliveWorkerThread MaxTimeout [' + str(self.maxTimeout) + '] seconds.')
 
     def __enter__(self):
         self.start()
@@ -62,7 +63,7 @@ class KeepAliveThread(Thread):
                 if self.exit_flag.wait(timeout=TIME_PERIOD):
                     break
                 totalWait = totalWait + TIME_PERIOD
-                if totalWait >= MAX_TIMEOUT:
+                if totalWait >= self.maxTimeout:
                     self.wasTimeout = True
                     self.rootLogger.info('Thread [' + str(self.forThread) +'] waited for too long. Terminating.')
                     self.complete()

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -106,7 +106,8 @@ def get_service_health(service_host):
 header_to_json_mappings = {"os":"InspectionMetadata-Operating-System",
                 "os_distribution":"InspectionMetadata-OS-Distribution", 
                 "os_product_name":"InspectionMetadata-Product-Name",
-                "os_disk_configuration":"InspectionMetadata-Disk-Configuration"}
+                "os_disk_configuration":"InspectionMetadata-Disk-Configuration",
+                "thread_timeout":"KeepAliveThread-Timeout-In-Mins"}
                         
 
 relative_subdirectory = "TestDownloads"
@@ -211,17 +212,11 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
         test_duration = ((test_end_time - test_start_time).total_seconds()/60)
 
         if inspection_test["title"] == "KeepAliveThread timeout" and test_passed:
-            timeoutHeaderVal = res.getheader("KeepAliveThread-Timeout-In-Mins")
-            print(timeoutHeaderVal)
-            if timeoutHeaderVal == None:
-                failed_tests.append(inspection_test["title"])
-                test_result = "FAILED"
-                print("ERROR: Could not extract timeout value from response header" )
-            elif test_duration > 1.1 and test_files(inspection_test, folder_path ) and timeoutHeaderVal != "1":
+            if test_duration > 1.1 and test_files(inspection_test, folder_path ):
                 failed_tests.append(inspection_test["title"])
                 test_result = "FAILED"
                 print("ERROR: Test did not timeout after 1 minutes" )
-            elif test_headers(mappings, inspection_test) and not test_files(inspection_test, folder_path ) and timeoutHeaderVal == "1":
+            elif test_headers(mappings, inspection_test) and not test_files(inspection_test, folder_path ):
                 test_passed = True
                 passed_tests.append(inspection_test["title"])
                 test_result = "PASSED"

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -199,6 +199,7 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
                     f.write(res.read())
                 
                 response_headers = res.getheaders()
+                print("RESPONSE HEADERS:")
                 print(response_headers)
                 extract_zip(file_path, folder_path)
                 mappings = header_to_json_mappings
@@ -210,11 +211,17 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
         test_duration = ((test_end_time - test_start_time).total_seconds()/60)
 
         if inspection_test["title"] == "KeepAliveThread timeout" and test_passed:
-            if test_duration > 1.1 and test_files(inspection_test, folder_path ):
+            timeoutHeaderVal = res.getheader("KeepAliveThread-Timeout-In-Mins")
+            print(timeoutHeaderVal)
+            if timeoutHeaderVal == None:
                 failed_tests.append(inspection_test["title"])
                 test_result = "FAILED"
-                print("Error: Test did not timeout after 1 minutes" )
-            elif test_headers(mappings, inspection_test) and not test_files(inspection_test, folder_path ):
+                print("ERROR: Could not extract timeout value from response header" )
+            elif test_duration > 1.1 and test_files(inspection_test, folder_path ) and timeoutHeaderVal != "1":
+                failed_tests.append(inspection_test["title"])
+                test_result = "FAILED"
+                print("ERROR: Test did not timeout after 1 minutes" )
+            elif test_headers(mappings, inspection_test) and not test_files(inspection_test, folder_path ) and timeoutHeaderVal == "1":
                 test_passed = True
                 passed_tests.append(inspection_test["title"])
                 test_result = "PASSED"

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -107,7 +107,7 @@ header_to_json_mappings = {"os":"InspectionMetadata-Operating-System",
                 "os_distribution":"InspectionMetadata-OS-Distribution", 
                 "os_product_name":"InspectionMetadata-Product-Name",
                 "os_disk_configuration":"InspectionMetadata-Disk-Configuration",
-                "thread_timeout":"KeepAliveThread-Timeout-In-Mins"}
+                "expected_timeout":"KeepAliveThread-Timeout-In-Mins"}
                         
 
 relative_subdirectory = "TestDownloads"
@@ -173,8 +173,8 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
         else:
             DATA = urllib.parse.urlencode({"saskey":storage_sas})
 
-        if inspection_test["title"] == "KeepAliveThread timeout":
-            DATA = urllib.parse.urlencode({"saskey":storage_sas, "timeout":1})
+        if "timeout_override" in inspection_test:
+            DATA = urllib.parse.urlencode({"saskey":storage_sas, "timeout":inspection_test["timeout_override"]})
 
         DATA = DATA.encode('ascii')
         req = urllib.request.Request(url=uri,data=DATA,method='POST')

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -209,17 +209,22 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
         test_end_time = datetime.datetime.now()
         test_duration = ((test_end_time - test_start_time).total_seconds()/60)
 
-        if inspection_test["title"] == "KeepAliveThread timeout":
-            if test_duration > 1.1:
-                test_passed = False
+        if inspection_test["title"] == "KeepAliveThread timeout" and test_passed:
+            if test_duration > 1.1 and test_files(inspection_test, folder_path ):
+                failed_tests.append(inspection_test["title"])
+                test_result = "FAILED"
                 print("Error: Test did not timeout after 1 minutes" )
-
-        if test_passed and test_headers(mappings, inspection_test) and test_files(inspection_test, folder_path ) and test_content(inspection_test, folder_path ):
-            passed_tests.append(inspection_test["title"])
-            test_result = "PASSED"
+            elif test_headers(mappings, inspection_test) and not test_files(inspection_test, folder_path ):
+                test_passed = True
+                passed_tests.append(inspection_test["title"])
+                test_result = "PASSED"
         else:
-            failed_tests.append(inspection_test["title"])
-            test_result = "FAILED"
+            if test_passed and test_headers(mappings, inspection_test) and test_files(inspection_test, folder_path ) and test_content(inspection_test, folder_path ):
+                passed_tests.append(inspection_test["title"])
+                test_result = "PASSED"
+            else:
+                failed_tests.append(inspection_test["title"])
+                test_result = "FAILED"
 
         print("Test '{1}' {2}. Test duration {0} minutes".format( str( test_duration ), inspection_test["title"],test_result  ) )
 

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -82,6 +82,9 @@ def test_content(inspection_test, extracted_base):
 
 
 def extract_zip(zipFilename, basename):
+    if os.path.exists(basename):
+        shutil.rmtree(basename)
+
     os.makedirs(basename)
     zf = zipfile.ZipFile(zipFilename) 
     zf.extractall(basename)

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -11,6 +11,7 @@
       "os_distribution": "centos",
       "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
     },
     {
@@ -22,6 +23,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/device_1/system-data/etc/ssh/sshd_config", "/device_1/system-data/var/log/cloud-init.log", "/device_1/system-data/var/log/dmesg" ]
     },
     {
@@ -33,6 +35,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
     },
     {
@@ -44,6 +47,7 @@
       "os_distribution": "freebsd",
       "os_product_name": "FreeBSD 10.3-RELEASE (GENERIC) #2 d912ed6(10.3.0_hyperv): Thu May 19 09:20:45 CST 2016",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/device_0/etc/rc.conf", "/device_0/etc/fstab", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
     },
     {
@@ -55,6 +59,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/device_0/Windows/Setup/State/State.ini", "/device_0/Windows/Panther/WaSetup.xml" ],
       "file_content":{"/device_0/Windows/Setup/State/State.ini":"IMAGE_STATE_COMPLETE"}
     },
@@ -67,6 +72,7 @@
       "os_distribution": "sles",
       "os_product_name": "SUSE Linux Enterprise Server 12 SP1",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": ["/device_0/etc/hostname"],
       "file_content":{"/device_0/etc/hostname":"suse12-sp1"}
     },
@@ -79,6 +85,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/registry.json"]
     },
     {
@@ -90,6 +97,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Encrypted",
+      "thread_timeout": "19",
       "files_present": [ ]
     },
     {
@@ -101,6 +109,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Encrypted",
+      "thread_timeout": "19",
       "files_present": [ ]
     },
     {
@@ -112,6 +121,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/device_0/ProgramData/ASRSetupLogs/ASRUnifiedAgentInstaller.log", "/device_0/Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log", "/device_0/Windows/System32/winevt/Logs/System.evtx"]
     },
     {
@@ -123,6 +133,7 @@
       "os_distribution": "rhel",
       "os_product_name": "Red Hat Enterprise Linux Server release 6.8 (Santiago)",
       "os_disk_configuration": "Standard",
+      "thread_timeout": "19",
       "files_present": [ "/device_0/var/log/waagent.log", "/device_0/var/log/AzureRcmCli.log", "/device_0/var/log/evtcollforw.log","device_0/var/log/azure/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/1.0.0.2/CommandExecution.log"]
     },
     {
@@ -134,6 +145,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "",
+      "thread_timeout": "19",
       "shouldFail" : true
     },
     {
@@ -145,6 +157,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "",
+      "thread_timeout": "19",
       "shouldFail" : true
     },
     {
@@ -156,6 +169,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "",
+      "thread_timeout": "19",
       "shouldFail" : true
     },
     {
@@ -166,7 +180,9 @@
       "os": "windows",
       "os_distribution": "",
       "os_product_name": "",
-      "os_disk_configuration": "Standard"
+      "os_disk_configuration": "Standard",
+      "thread_timeout": "1",
+      "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
     }
   ]
 }

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -157,6 +157,16 @@
       "os_product_name": "",
       "os_disk_configuration": "",
       "shouldFail" : true
+    },
+    {
+      "title": "KeepAliveThread timeout",
+      "description": "Validate that disk inspect should stop after after roughly 1 minute with the provided timeout override value. ",
+      "vhd_relative_path": "/windows/craigw-2008R2.vhd",
+      "manifest": "diagnostic",
+      "os": "windows",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "Standard"
     }
   ]
 }

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -11,7 +11,7 @@
       "os_distribution": "centos",
       "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
     },
     {
@@ -23,7 +23,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/device_1/system-data/etc/ssh/sshd_config", "/device_1/system-data/var/log/cloud-init.log", "/device_1/system-data/var/log/dmesg" ]
     },
     {
@@ -35,7 +35,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
     },
     {
@@ -47,7 +47,7 @@
       "os_distribution": "freebsd",
       "os_product_name": "FreeBSD 10.3-RELEASE (GENERIC) #2 d912ed6(10.3.0_hyperv): Thu May 19 09:20:45 CST 2016",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/device_0/etc/rc.conf", "/device_0/etc/fstab", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
     },
     {
@@ -59,7 +59,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/device_0/Windows/Setup/State/State.ini", "/device_0/Windows/Panther/WaSetup.xml" ],
       "file_content":{"/device_0/Windows/Setup/State/State.ini":"IMAGE_STATE_COMPLETE"}
     },
@@ -72,7 +72,7 @@
       "os_distribution": "sles",
       "os_product_name": "SUSE Linux Enterprise Server 12 SP1",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": ["/device_0/etc/hostname"],
       "file_content":{"/device_0/etc/hostname":"suse12-sp1"}
     },
@@ -85,7 +85,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/registry.json"]
     },
     {
@@ -97,7 +97,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Encrypted",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ ]
     },
     {
@@ -109,7 +109,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Encrypted",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ ]
     },
     {
@@ -121,7 +121,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/device_0/ProgramData/ASRSetupLogs/ASRUnifiedAgentInstaller.log", "/device_0/Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log", "/device_0/Windows/System32/winevt/Logs/System.evtx"]
     },
     {
@@ -133,7 +133,7 @@
       "os_distribution": "rhel",
       "os_product_name": "Red Hat Enterprise Linux Server release 6.8 (Santiago)",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "files_present": [ "/device_0/var/log/waagent.log", "/device_0/var/log/AzureRcmCli.log", "/device_0/var/log/evtcollforw.log","device_0/var/log/azure/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/Microsoft.Azure.RecoveryServices.SiteRecovery.Linux/1.0.0.2/CommandExecution.log"]
     },
     {
@@ -145,7 +145,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "shouldFail" : true
     },
     {
@@ -157,7 +157,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "shouldFail" : true
     },
     {
@@ -169,7 +169,7 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "",
-      "thread_timeout": "19",
+      "expected_timeout": "19",
       "shouldFail" : true
     },
     {
@@ -181,8 +181,22 @@
       "os_distribution": "",
       "os_product_name": "",
       "os_disk_configuration": "Standard",
-      "thread_timeout": "1",
+      "timeout_override": "1",
+      "expected_timeout": "1",
       "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
+    },
+    {
+      "title": "Invalid KeepAliveThread timeout",
+      "description": "Test should use default thread timeout of 19 mins when invalid arg (negative value) is given.",
+      "vhd_relative_path": "/linux/craigw-centos72016320152715.vhd",
+      "manifest": "diagnostic",
+      "os": "linux",
+      "os_distribution": "centos",
+      "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
+      "os_disk_configuration": "Standard",
+      "timeout_override": "-10",
+      "expected_timeout": "19",
+      "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]      
     }
   ]
 }


### PR DESCRIPTION
Parameterizing KeepAliveThread MaxTimeout so it can be overridden. This is so that certain types of calls that go through ACIS (for example, requests made from ASC Portal) don't have to timeout and will run to completion. Default remains 19 mins when new param is not given.