### PR TITLE
Remove nginx IP rules

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -30,18 +30,7 @@ http {
 
     # Configuration for the server
     server {
-        # loopback adaptor
-        allow 127.0.0.1;
-        # ACIS
-        allow 70.37.89.222;
-        allow 65.52.193.203;
-        allow 13.64.115.203;
-        # Health Check
-        allow 191.236.103.205;
-        # docker bridge network https://docs.docker.com/engine/userguide/networking/
-        #   allows calls from host for automated testing
-        allow 172.17.0.1;
-        deny all;
+        allow all;
 
         # Running port
         listen 8080 ssl;


### PR DESCRIPTION
Removed all `allow` and `deny` rules from nginx server configuration.