### PR TITLE
Add Release Name Logging

### DIFF
--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -99,10 +99,14 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
     def __init__(self, request, client_address, server ):    
         self.hostMetadata = getHostMetadata()
         self.containerId = getContainerId() 
-        if os.environ['CONTAINER_VERSION']:
+        if 'CONTAINER_VERSION' in os.environ:
             self.containerVersion = os.environ['CONTAINER_VERSION']
         else:
             self.containerVersion = 'not set'
+        if 'RELEASENAME' in os.environ:
+            self.releaseName=os.environ['RELEASENAME']
+        else:
+            self.releaseName="AzureDiskInspect-Release-MANUAL"
         self.InitializeAppInsights() 
         super().__init__(request, client_address, server) # invoke the base class constructor
 
@@ -120,6 +124,7 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
         telemetryhandler.setFormatter(logFormatter)
         telemetryhandler.client.context.application.id = "DiskInspect-Service"
         telemetryhandler.client.context.application.ver = self.containerVersion
+        telemetryhandler.client.context.properties['releaseName'] = self.releaseName
         self.telemetryLogger.addHandler(telemetryhandler)
 
         self.telemetryClient = telemetryhandler.client

--- a/pyServer/main.py
+++ b/pyServer/main.py
@@ -14,12 +14,15 @@ Globals
 IP_ADDRESS = '127.0.0.1'
 PORT = 8081
 LOG_FILE = "/var/log/azureDiskInspectSvc.log"
-
+if 'RELEASENAME' in os.environ:
+    RELEASENAME=os.environ['RELEASENAME']
+else:
+    RELEASENAME="AzureDiskInspect-Release-MANUAL"
 
 """
 Logger Initialization
 """
-logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-7.7s]: %(message)s")
+logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-7.7s] ["+RELEASENAME+"]: %(message)s")
 rootLogger = logging.getLogger()
 rootLogger.setLevel(logging.DEBUG)
 
@@ -44,7 +47,7 @@ if __name__ == '__main__':
     AzureDiskInspectService.serviceMetrics = serviceMetrics
     server = ThreadingServer(server_address, AzureDiskInspectService)
     rootLogger.info('Started AzureDiskInspectService on IP: ' + str(IP_ADDRESS) + ', Port: ' + str(PORT))
-    
+
     try:
         while (True):
             sys.stdout.flush()

--- a/pyServer/main.py
+++ b/pyServer/main.py
@@ -14,15 +14,12 @@ Globals
 IP_ADDRESS = '127.0.0.1'
 PORT = 8081
 LOG_FILE = "/var/log/azureDiskInspectSvc.log"
-if 'RELEASENAME' in os.environ:
-    RELEASENAME=os.environ['RELEASENAME']
-else:
-    RELEASENAME="AzureDiskInspect-Release-MANUAL"
+
 
 """
 Logger Initialization
 """
-logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-7.7s] ["+RELEASENAME+"]: %(message)s")
+logFormatter = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelname)-7.7s]: %(message)s")
 rootLogger = logging.getLogger()
 rootLogger.setLevel(logging.DEBUG)
 
@@ -47,7 +44,7 @@ if __name__ == '__main__':
     AzureDiskInspectService.serviceMetrics = serviceMetrics
     server = ThreadingServer(server_address, AzureDiskInspectService)
     rootLogger.info('Started AzureDiskInspectService on IP: ' + str(IP_ADDRESS) + ', Port: ' + str(PORT))
-
+    
     try:
         while (True):
             sys.stdout.flush()


### PR DESCRIPTION
Release Name added to Applnsights customDimensions.
If not found in environment variables, default is "AzureDiskInspect-Release-MANUAL".

Also fixed check for container version in env - previously this would error if it did not exist.
