### PR TITLE
collect machine.config

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -208,6 +208,8 @@ File Path | Manifest
 /ProgramData/ASRSetupLogs/WrapperUnifiedAgent.log | site-recovery 
 /Windows/Inf/netcfg\*.\*etl | diagnostic, normal 
 /Windows/Inf/setupapi.dev.log | diagnostic, normal 
+/Windows/Microsoft.NET/Framework/v4.0.30319/Config/machine.config | diagnostic 
+/Windows/Microsoft.NET/Framework64/v4.0.30319/Config/machine.config | diagnostic 
 /Windows/Panther/FastCleanup/setupact.log | diagnostic, eg, normal 
 /Windows/Panther/UnattendGC/setupact.log | diagnostic, eg, normal 
 /Windows/Panther/WaSetup.log | diagnostic, eg, normal 
@@ -336,4 +338,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-08-14 14:32:27.595617`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-09-11 21:51:08.358944`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -460,6 +460,8 @@ diagnostic | copy | /Windows/debug/mrt.log
 diagnostic | copy | /Windows/debug/DCPROMO.LOG
 diagnostic | copy | /Windows/debug/dcpromoui.log
 diagnostic | copy | /Windows/debug/PASSWD.LOG
+diagnostic | copy | /Windows/Microsoft.NET/Framework/v4.0.30319/Config/machine.config
+diagnostic | copy | /Windows/Microsoft.NET/Framework64/v4.0.30319/Config/machine.config
 diagnostic | list | /WindowsAzure
 diagnostic | list | /Packages/Plugins
 diagnostic | copy | /WindowsAzure/Logs/Telemetry.log
@@ -880,4 +882,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-08-14 14:32:27.595617`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-09-11 21:51:08.358944`*

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -89,6 +89,10 @@ copy,/Windows/debug/DCPROMO.LOG
 copy,/Windows/debug/dcpromoui.log
 copy,/Windows/debug/PASSWD.LOG
 
+echo,### .NET ###
+copy,/Windows/Microsoft.NET/Framework/v4.0.30319/Config/machine.config
+copy,/Windows/Microsoft.NET/Framework64/v4.0.30319/Config/machine.config
+
 echo,### Guest Agent ###
 ll,/WindowsAzure
 ll,/Packages/Plugins


### PR DESCRIPTION
Customers may set a PROXY server in machine.config, which influeces the
guest agent.  It is difficult to diagnose without this file.