### PR TITLE
Adding support to use Blob SAS Url to perform data transport (#69)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - 3.5
 install:
 - travis_wait 30 ./build.sh ~/docker_build.txt
+- pip3 install azure-storage-blob
 - mkdir $HOME/azdis_ssl
 - openssl req -x509 -newkey rsa:2048 -keyout $HOME/azdis_ssl/azdis_private.rsa -out
   $HOME/azdis_ssl/azdis_public.crt -days 365 -nodes -subj "/CN=localhost"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     git \
     nginx \
     python3-pip \
+    libssl-dev \
  && DEBIAN_FRONTEND=noninteractive apt-get build-dep -y \
     libguestfs
 
@@ -40,6 +41,7 @@ COPY pyServer/manifests/ /etc/azdis/
 RUN ln -s -f /usr/bin/python3 /usr/bin/python
 
 # Install AppInsights 
+RUN pip3 install azure-storage-blob
 RUN pip3 install applicationinsights
 
 # Expose port 8080 for nginx

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -3,6 +3,7 @@
 * [Registry query](registry.md)
 * [Disk Info](diskinfo.md)
 * [Http Headers](http_headers.md)
+* [Result Upload](result_upload.md)
 
 ## Manifest Information
 * [Manifest content by manifest name](manifest_content.md)

--- a/docs/result_upload.md
+++ b/docs/result_upload.md
@@ -1,0 +1,19 @@
+## Inspection result upload ##
+
+The disk inspection is now capable of returning the inspection result in two different ways: http response body (classic) or blob upload.
+
+The method of how the inspection result is returned is determined by an input parameter on the POST request: `blobsasurl`
+
+__Sample input__
+
+If `blobsasurl` is supplied as follows, the service will use the given blob SAS Url to upload the result file. 
+
+For example:
+
+`curl -X POST -k "https://127.0.0.1:8080/eb8482c8-adbd-46fa-a0d5-0ad694eae404/diagnostic/foo/bar/abcd" --data-urlencode "timeout=30" --data-urlencode "saskey=sv=2017-04-17&some_sas_token" --data-urlencode "blobsasurl=https://myaccount.blob.core.windows.net/mycontainer/output.zip?sp=some_sas_token"`
+
+If the 'blobsasurl' parameter is not supplied on the POST request, the service will return the inspection result zip file in the Http response as it had before.
+
+For example:
+
+`curl -X POST -k "https://127.0.0.1:8080/eb8482c8-adbd-46fa-a0d5-0ad694eae404/diagnostic/foo/bar/abcd" --data-urlencode "timeout=30" --data-urlencode "saskey=sv=2017-04-17&some_sas_token" -o output.zip`

--- a/pyServer/AzureDiskInspectService.py
+++ b/pyServer/AzureDiskInspectService.py
@@ -19,6 +19,18 @@ from applicationinsights import TelemetryClient
 from applicationinsights.logging import LoggingHandler
 import json
 
+from azure.storage.blob import (
+    BlockBlobService,
+    ContainerPermissions,
+    BlobPermissions,
+    PublicAccess,
+)
+from azure.storage.common import (
+    AccessPolicy,
+    ResourceTypes,
+    AccountPermissions,
+)
+
 OUTPUTDIRNAME = '/output'
 DEFAULT_TIMEOUT_IN_MINS = 19
 
@@ -74,6 +86,14 @@ Threading server to handle multiple web requests.
 """
 class ThreadingServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     pass
+
+class InvalidBlobSasUrlException(Exception):
+   """Raised when an invalid Blob Sas Url is received as parameter input"""
+   pass
+
+class BlobUploadException(Exception):
+   """Raised when an error is encountered during uploading result to Blob via Sas Url"""
+   pass
 
 """
 Request Handler for the Service.
@@ -213,46 +233,141 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
         return operationId, mode, modeMajorSkipTo, modeMinorSkipTo, storageAcctName, container_blob_name, storageUrl
 
     """
-    Upload a local file as a HTTP binary response.
+    Validate and parse the given destination Blob Sas Url.
+
+    A Blob Sas Url has these components:
+
+        https://<a. Account_Name>.<b. Blob_endpoint_suffix>/<c. Container_Name>/<d. Blob_Name>?<e. Sas_Token>
+
+    For example:
+
+        https://myaccount.blob.core.windows.net/mycontainer/outputfile.zip?some_sas_token
+
+    These can be parsed using the Python urllib.parse.urlparse tool by looking up:
+
+        urlparse(blobSasUrl).netloc = <a. Account_Name>.<b. Blob_endpoint_suffix>
+        urlparse(blobSasUrl).path = <c. Container_Name>/<d. Blob_Name>
+        urlparse(blobSasUrl).query: = <e. Sas_Token>
+
+    The following validating and parsing logic is based on the pattern described.
     """
-    def uploadFile(self, http_headers, outputFileName, isPartial, osType):
+    def ValidateAndParseBlobSasUrl(self, blobSasUrl):
+        self.telemetryLogger.info("Validating input destination Blob Sas Url.")
+
+        urlParts = urllib.parse.urlparse(blobSasUrl)
+
+        if not urlParts.path or len(urlParts.path) == 0:
+            raise InvalidBlobSasUrlException('Input Blob SAS Url for upload is missing Container and Blob info.')
+        if not urlParts.query or len(urlParts.query) == 0:
+            raise InvalidBlobSasUrlException('Input Blob SAS url for upload is missing SAS token.')
+
+        if urlParts.path[0] == '/':
+            blob_storage_path = urlParts.path[1:]
+        else:
+            blob_storage_path = urlParts.path
+
+        if 'blob' not in urlParts.netloc:
+            raise InvalidBlobSasUrlException('Input Blob SAS url for upload is not pointing to a valid Azure Blob endpoint.')
+
+        self.destination_storage_account = urlParts.netloc.split('.')[0]
+
+        if not self.destination_storage_account:
+            raise InvalidBlobSasUrlException('Input Blob SAS url for upload does not contain storage account.')
+
+        urlSplit = blob_storage_path.split('/')
+
+        if not len(urlSplit) == 2 or not urlSplit[0] or not urlSplit[1]:
+            raise InvalidBlobSasUrlException('Input Blob SAS Url is not in the right format.')
+        
+        self.destination_container_name = urlSplit[0]
+        self.destination_blob_name = urlSplit[1]
+        self.destination_sas_token = urlParts.query
+
+        self.telemetryLogger.info("Destination Blob Storage Account: " + self.destination_storage_account)
+        self.telemetryLogger.info("Container Name: " + self.destination_container_name)
+        self.telemetryLogger.info("Blob Name: " + self.destination_blob_name)
+
+    """
+    Upload the given file to destination Blob storage using the given Sas Url.
+    """
+    def uploadFileWithBlobSasUrl(self, file_name_full_path):
+        retryRemaining = 3
+        while retryRemaining > 0:
+            try:
+                sas_service = BlockBlobService(account_name=self.destination_storage_account, sas_token=self.destination_sas_token)
+                self.telemetryLogger.info('Uploading to Blob starting.')
+                start_time = datetime.now()
+                sas_service.create_blob_from_path(self.destination_container_name, self.destination_blob_name, file_name_full_path)
+                self.telemetryLogger.info('Uploading to Blob completed. Time take: ' + str((datetime.now() - start_time).total_seconds() * 1000) + ' ms')
+                break
+            except Exception as ex:
+                retryRemaining -= 1
+                if retryRemaining <= 0:
+                    self.telemetryLogger.error('Encountered error during blob upload multiple times after exhausting all retry attempts')
+                    raise BlobUploadException(ex)
+                exMessage = str(ex)
+                self.telemetryLogger.warning('Encountered error during blob upload: ' + exMessage)
+                self.telemetryLogger.warning('Retrying. ' + str(retryRemaining) + ' attempt(s) remaining.')
+
+    """
+    Upload a local file either as a HTTP binary response or upload to a given destination blob storage.
+    """
+    def uploadFile(self, http_headers, outputFileName, isPartial, osType, blobSasUrl):
+
+        if blobSasUrl:
+            self.telemetryLogger.info('Uploading result to Blob storage.')
+            self.uploadFileWithBlobSasUrl(file_name_full_path=outputFileName)
+            self.PrepareHttpResponseHeaders(http_headers)
+            self.wfile.write(bytes('Content-Type: text/plain\r\n', 'utf-8'))
+            statinfo = os.stat(outputFileName)
+            self.wfile.write(bytes('Content-Length: 0\r\n', 'utf-8'))
+            self.wfile.write(bytes('\r\n', 'utf-8'))
+            self.wfile.flush()
+        else:
+            self.telemetryLogger.info('Writing result to Http reponse.')
+            self.PrepareHttpResponseHeaders(http_headers)
+            self.wfile.write(bytes('Content-Type: application/zip\r\n', 'utf-8'))
+            
+            statinfo = os.stat(outputFileName)
+            self.wfile.write(bytes('Content-Length: {0}\r\n'.format(
+                str(statinfo.st_size)), 'utf-8'))
+
+            strOutputFileName = os.path.basename(outputFileName) + "-" + osType
+            if isPartial:
+                strOutputFileName = strOutputFileName + "-partial"
+
+            self.wfile.write(bytes(
+                'Content-Disposition: Attachment; filename={0}\r\n'.format(
+                    os.path.basename(strOutputFileName)), 'utf-8'))
+            self.wfile.write(bytes('\r\n', 'utf-8'))
+            self.wfile.flush()
+
+            # Write the zip file payload
+            outputFileSize = os.path.getsize(outputFileName)
+            readSize = 0
+            with open(outputFileName, 'rb') as outputFileObj:
+                buf = None
+                while (True):
+                    buf = outputFileObj.read(64 * 1024)
+                    if (not buf):
+                        break
+                    readSize = readSize + len(buf)
+                    printProgress(
+                        readSize, outputFileSize, prefix='Progress:', suffix='Complete', barLength=50)
+                    self.wfile.write(buf)
+            self.wfile.flush()
+            
+            self.telemetryLogger.info('Finished writing output Http response.')
+
+    def PrepareHttpResponseHeaders(self, http_headers):
         # Set the HTTP headers, including extended content from GuestFishWrapper
         self.wfile.write(bytes('HTTP/1.1 200 OK\r\n', 'utf-8'))
-        self.wfile.write(bytes('Content-Type: application/zip\r\n', 'utf-8'))
+
         for header in http_headers:
             header_value = str(http_headers[header])
             if len( header_value ) > 0:
                 self.wfile.write(bytes( '{0}: {1}\r\n'.format( header,header_value ), 'utf-8' ))
                 self.telemetryLogger.info('GuestFishWrapper Header "' + header + '" = "' + header_value +'"')
-
-        statinfo = os.stat(outputFileName)
-        self.wfile.write(bytes('Content-Length: {0}\r\n'.format(
-            str(statinfo.st_size)), 'utf-8'))
-
-        strOutputFileName = os.path.basename(outputFileName) + "-" + osType
-        if isPartial:
-            strOutputFileName = strOutputFileName + "-partial"
-
-        self.wfile.write(bytes(
-            'Content-Disposition: Attachment; filename={0}\r\n'.format(
-                os.path.basename(strOutputFileName)), 'utf-8'))
-        self.wfile.write(bytes('\r\n', 'utf-8'))
-        self.wfile.flush()
-
-        # Write the zip file payload
-        outputFileSize = os.path.getsize(outputFileName)
-        readSize = 0
-        with open(outputFileName, 'rb') as outputFileObj:
-            buf = None
-            while (True):
-                buf = outputFileObj.read(64 * 1024)
-                if (not buf):
-                    break
-                readSize = readSize + len(buf)
-                printProgress(
-                    readSize, outputFileSize, prefix='Progress:', suffix='Complete', barLength=50)
-                self.wfile.write(buf)
-        self.wfile.flush()
 
     """
     GET request handler
@@ -357,8 +472,14 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                     self.telemetryLogger.info('WARNING: Received timeout override is invalid: {0}. Default will be used.'.format(timeoutInMinsStr))
 
             timeoutInMins = int(timeoutInMinsStr)
-
             self.telemetryLogger.info('Using timeout value: ' + str(timeoutInMins)+ ' min(s)')
+
+            if b'blobsasurl' in postvars:
+                blobSasUrl = str(postvars[b'blobsasurl'][0], encoding='UTF-8')
+                self.ValidateAndParseBlobSasUrl(blobSasUrl)
+                self.telemetryLogger.info('Received a valid Blob Sas url for upload. Result will be uploaded to Blob directly instead of Http response.')
+            else:
+                blobSasUrl = ""
 
             # update the fields in the telemetry client
             for h in self.telemetryLogger.handlers:
@@ -391,14 +512,15 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
                 with GuestFishWrapper(self.telemetryLogger, self, storageUrl, OUTPUTDIRNAME, operationId, mode, modeMajorSkipTo, modeMinorSkipTo, kpThread, runWithCredscan) as gfWrapper:
                     gfWrapper.start()
                     # Upload the ZIP file
-                    if gfWrapper.outputFileName:    
-                        kpThread.avoidSendingKeepAlive = True  # stop KeepAlive while we send the zip to avoid corruption issue
+                    if gfWrapper.outputFileName:
+                        if not blobSasUrl:
+                            self.telemetryLogger.info('Turning off KeepAlive messages before writing result to response.')
+                            kpThread.avoidSendingKeepAlive = True  # stop KeepAlive if we send the zip in response to avoid corruption issue
                         outputFileName = gfWrapper.outputFileName            
                         outputFileSize = round(os.path.getsize(outputFileName) / 1024, 2)
                         self.telemetryLogger.info('Uploading: ' + outputFileName + ' (' + str(outputFileSize) + 'kb)')
                         gfWrapper.metadata_pairs[ResponseHeaderMetadata.KEEPALIVETHREAD_TIMEOUT_IN_MINS] = timeoutInMins
-                        self.uploadFile(gfWrapper.metadata_pairs, outputFileName, kpThread.wasTimeout, gfWrapper.osType)
-                        self.telemetryLogger.info('Upload completed.')
+                        self.uploadFile(gfWrapper.metadata_pairs, outputFileName, kpThread.wasTimeout, gfWrapper.osType, blobSasUrl)
 
                         successElapsed = datetime.now() - start_time
                         self.serviceMetrics.SuccessRequests = self.serviceMetrics.SuccessRequests + 1
@@ -441,6 +563,18 @@ class AzureDiskInspectService(http.server.BaseHTTPRequestHandler):
             telemetryException = ex
             failureStatusText = 'Invalid SAS uri'
             self.telemetryLogger.error(failureStatusText)  # don't raise exception  
+        except InvalidBlobSasUrlException as ex:
+            unexpectedError = False
+            failureResultCode = 400
+            telemetryException = ex
+            failureStatusText = 'Invalid Blob SAS uri for upload'
+            self.telemetryLogger.error(failureStatusText)
+        except BlobUploadException as ex:
+            unexpectedError = False
+            failureResultCode = 500
+            telemetryException = ex
+            failureStatusText = 'Error encountered during blob upload'
+            self.telemetryLogger.error(failureStatusText)
         except ValueError as ex:
             unexpectedError = True
             telemetryException = ex

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -15,6 +15,17 @@ import inspect
 import re
 import subprocess
 
+from azure.storage.blob import (
+    BlockBlobService,
+    ContainerPermissions,
+    BlobPermissions,
+    PublicAccess,
+)
+
+class InvalidBlobSasUrlException(Exception):
+   """Raised when an invalid Blob Sas Url is received as parameter input"""
+   pass
+
 def test_headers(header_to_json_mappings, inspection_test):
     #validate headers with test values
     for test_setting in header_to_json_mappings:
@@ -102,28 +113,75 @@ def get_service_health(service_host):
         return parseHealthResponse(res.read().decode('utf-8'))
     except urllib.error.HTTPError as e:
         return {}
+
+def download_result_blob(blobSasUrl, local_file_path):
+    urlParts = urllib.parse.urlparse(blobSasUrl)
+
+    if not urlParts.path or len(urlParts.path) == 0:
+        raise InvalidBlobSasUrlException('Input Blob SAS Url for upload is missing Container and Blob info.')
+    if not urlParts.query or len(urlParts.query) == 0:
+        raise InvalidBlobSasUrlException('Input Blob SAS url for upload is missing SAS token.')
+
+    if urlParts.path[0] == '/':
+        blob_storage_path = urlParts.path[1:]
+    else:
+        blob_storage_path = urlParts.path
+
+    if 'blob' not in urlParts.netloc:
+        raise InvalidBlobSasUrlException('Input Blob SAS url for upload is not pointing to a valid Azure Blob endpoint.')
+
+    destination_storage_account = urlParts.netloc.split('.')[0]
+
+    if not destination_storage_account:
+        raise InvalidBlobSasUrlException('Input Blob SAS url for upload does not contain storage account.')
+
+    urlSplit = blob_storage_path.split('/')
+
+    if not len(urlSplit) == 2 or not urlSplit[0] or not urlSplit[1]:
+        raise InvalidBlobSasUrlException('Input Blob SAS Url is not in the right format.')
+    
+    destination_container_name = urlSplit[0]
+    destination_blob_name = urlSplit[1]
+    destination_sas_token = urlParts.query
+
+    blob_service = BlockBlobService(
+        account_name = destination_storage_account,
+        sas_token = destination_sas_token,
+    )
+
+    print("\nDownloading blob to " + local_file_path)
+    blob_service.get_blob_to_path(destination_container_name, destination_blob_name, local_file_path)
+
         
 header_to_json_mappings = {"os":"InspectionMetadata-Operating-System",
                 "os_distribution":"InspectionMetadata-OS-Distribution", 
                 "os_product_name":"InspectionMetadata-Product-Name",
                 "os_disk_configuration":"InspectionMetadata-Disk-Configuration",
-                "expected_timeout":"KeepAliveThread-Timeout-In-Mins"}
+                "expected_timeout":"KeepAliveThread-Timeout-In-Mins",
+                "content_type":"Content-Type",
+                "content_length":"Content-Length"}
                         
 
 relative_subdirectory = "TestDownloads"
 download_directory = current_directory = os.path.split( inspect.getfile(inspect.currentframe() ) )[0]
 service_host = "https://localhost:8080"
 storage_sas = os.environ.get('LIBGUESTFS_SAS_KEY')
+blob_upload_sas_url = os.environ.get('BLOB_UPLOAD_SAS_URL')
+
 if len(sys.argv) > 1:
     download_directory  = sys.argv[1]
 if len(sys.argv) > 2:
     service_host = sys.argv[2]
 if len(sys.argv) > 3:
     storage_sas = sys.argv[3]
-
+if len(sys.argv) > 4:
+    blob_upload_sas_url = sys.argv[4]
 
 if storage_sas is None:
     print("ERROR: Unable to get SAS key from environment variable! Exiting...")
+    sys.exit(1)
+if blob_upload_sas_url is None:
+    print("ERROR: Unable to get Blob upload SAS Url from environment variable! Exiting...")
     sys.exit(1)
 
 script_start_time = datetime.datetime.now()
@@ -167,14 +225,26 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
             uri = "{0}/{1}/{2}/{3}{4}".format(service_host, operation_id, inspection_test["manifest"], "nosuchAccount",inspection_test["vhd_relative_path"]) 
         else:
             uri = "{0}/{1}/{2}/{3}{4}".format(service_host, operation_id, inspection_test["manifest"], storage_acct,inspection_test["vhd_relative_path"]) 
+
         print(uri)
+
+        blob_sas_to_use = blob_upload_sas_url
+        if "invalid_blob_token" in inspection_test:
+            blob_sas_to_use  = blob_upload_sas_url.replace(urllib.parse.urlparse(blob_upload_sas_url).query, "")
+            blob_sas_to_use  = blob_sas_to_use.replace("?", "")
+        elif "no_container_blob" in inspection_test:
+            blob_sas_to_use  = blob_upload_sas_url.replace(urllib.parse.urlparse(blob_upload_sas_url).path, "")
+        elif "bad_blob_endpoint" in inspection_test:
+            blob_sas_to_use  = blob_upload_sas_url.replace("blob", "foo")
+
         if inspection_test["title"] == "Invalid SAS":
             DATA = urllib.parse.urlencode({"saskey": "sv=2017-04-17&sr=c&sig=INVALIDSAS"})
+        elif "timeout_override" in inspection_test:
+            DATA = urllib.parse.urlencode({"saskey":storage_sas, "timeout":inspection_test["timeout_override"]})
+        elif "blob_upload" in inspection_test and inspection_test["blob_upload"] == True:
+            DATA = urllib.parse.urlencode({"saskey":storage_sas, "blobsasurl":blob_sas_to_use })
         else:
             DATA = urllib.parse.urlencode({"saskey":storage_sas})
-
-        if "timeout_override" in inspection_test:
-            DATA = urllib.parse.urlencode({"saskey":storage_sas, "timeout":inspection_test["timeout_override"]})
 
         DATA = DATA.encode('ascii')
         req = urllib.request.Request(url=uri,data=DATA,method='POST')
@@ -193,12 +263,18 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
         if not "shouldFail" in inspection_test:
             if test_passed: 
                 folder_name = "{0}_{1}".format( uri.split('/')[-1].split('.')[0],  inspection_test["manifest"])  # e.g. Centos7_normal  
-                folder_path = os.path.join( subdirectory, folder_name)
+                folder_path = os.path.join(subdirectory, folder_name)
                 file_path = folder_path+".zip"
+
                 print('INFO: Saving file to: ' + file_path )
-                with open(file_path, "wb") as f:
-                    f.write(res.read())
-                
+                if "blob_upload" not in inspection_test or inspection_test["blob_upload"] == False:
+                    # extract result from response
+                    with open(file_path, "wb") as f:
+                        f.write(res.read())
+                else:
+                    # download result from blob
+                    download_result_blob(blob_sas_to_use, file_path)
+
                 response_headers = res.getheaders()
                 print("RESPONSE HEADERS:")
                 print(response_headers)
@@ -232,6 +308,8 @@ with open(os.path.join(current_directory,'test_config.json'), "r") as json_confi
 
     print("==============================================")
     # Query health test: This ensures that we encountered only "expected" errors
+    # Sleep for 2 seconds first and let cleanup and service status update complete
+    time.sleep(2)
     test_name = 'Health result validation test'
     currentServiceHealth = get_service_health(service_host)
     print(currentServiceHealth)

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -197,6 +197,78 @@
       "timeout_override": "-10",
       "expected_timeout": "19",
       "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]      
+    },
+    {
+      "title": "Invalid Upload Blob SAS Url: Missing SAS token",
+      "description": "Test to ensure an invalid upload blob SAS uri is handled properly (performed in code)",
+      "vhd_relative_path": "/linux/UbuntuCore.vhd",
+      "manifest": "normal",
+      "os": "",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "",
+      "expected_timeout": "19",
+      "blob_upload": true,
+      "invalid_blob_token" : true,
+      "shouldFail" : true
+    },
+    {
+      "title": "Invalid Upload Blob SAS Url: Missing container and blob info",
+      "description": "Test to ensure an invalid storage account is handled properly (performed in code)",
+      "vhd_relative_path": "/linux/UbuntuCore.vhd",
+      "manifest": "normal",
+      "os": "",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "",
+      "expected_timeout": "19",
+      "blob_upload": true,
+      "no_container_blob" : true,
+      "shouldFail" : true
+    },
+    {
+      "title": "Invalid Upload Blob SAS Url: Invalid storage blob endpoint suffix",
+      "description": "Test to ensure an invalid storage account is handled properly (performed in code)",
+      "vhd_relative_path": "/linux/UbuntuCore.vhd",
+      "manifest": "normal",
+      "os": "",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "",
+      "expected_timeout": "19",
+      "blob_upload": true,
+      "bad_blob_endpoint" : true,
+      "shouldFail" : true
+    },
+    {
+      "title": "Blob Upload: Linux diagnostic (CentOS)",
+      "description": "test should return os as linux and the CentOS 7.0 product name",
+      "vhd_relative_path": "/linux/craigw-centos72016320152715.vhd",
+      "manifest": "diagnostic",
+      "os": "linux",
+      "os_distribution": "centos",
+      "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
+      "os_disk_configuration": "Standard",
+      "expected_timeout": "19",
+      "blob_upload": true,
+      "content_type": "text/plain",
+      "content_length": "0",
+      "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
+    },
+    {
+      "title": "Blob Upload: Windows 2008R2 diagnostic w/ one partition",
+      "description": "test should return os as windows. The disk has only 1 partition so we won't get a product name as it should use the service skipInspect logic",
+      "vhd_relative_path": "/windows/craigw-2008R2.vhd",
+      "manifest": "diagnostic",
+      "os": "windows",
+      "os_distribution": "",
+      "os_product_name": "",
+      "os_disk_configuration": "Standard",
+      "expected_timeout": "19",
+      "blob_upload": true,
+      "content_type": "text/plain",
+      "content_length": "0",
+      "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
     }
   ]
 }


### PR DESCRIPTION
* Adding blob url based data transport support.

* Adding unit tests to cover Linux/Windows and invalid inputs for blob upload scenario.

* Adding delay in unit test to allow service cleanup.

* Improved exception handling around blob upload in case underlying Storage clinet library throws.
Added time tracking for blob upload activity in telemetry.
Updated comments in response to PR comments.

* Adding retry around blob upload and leaving 'KeepAlive' on during blob upload.

* Fixing typos and commments.

* Adding new .md file to describe usage.

* Added result blob validation and updated invalid blob sas url input handling.

* Added Travis config changes.