### PR TITLE
Adding new response header "InspectionMetadata-Partial-Result"

### DIFF
--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -339,6 +339,8 @@ class GuestFishWrapper:
                     if (osProductName is not None):
                         self.metadata_pairs[DiskInspectionMetadata.INSPECTION_METADATA_PRODUCT_NAME] = osProductName
 
+                    self.metadata_pairs[DiskInspectionMetadata.INSPECTION_METADATA_PARTIAL_RESULT] = "false"
+
                     try:
                         # Mount all identified mount points
                         canProceedAfterMount = False
@@ -536,6 +538,7 @@ class GuestFishWrapper:
             if (self.kpThread.wasTimeout):
                 strLastGoodStep = str(lastGoodOperationMajorStep) + "." + str(lastGoodOperationMinorStep)
                 self.WriteToResultFile(operationOutFile, "\r\n##### WARNING: Partial results were collected as the operation was taking too long to complete. Consider retrying the operation specifying skip to step " + strLastGoodStep + " to continue gathering from last succesfully executed data collection step. #####")
+                self.metadata_pairs[DiskInspectionMetadata.INSPECTION_METADATA_PARTIAL_RESULT] = "true"
 
             # Scan results for secrets
             if self.runWithCredscan:
@@ -680,3 +683,4 @@ class DiskInspectionMetadata:
     INSPECTION_METADATA_DISK_CONFIGURATION = "InspectionMetadata-Disk-Configuration"
     INSPECTION_METADATA_OS_DISTRIBUTION = "InspectionMetadata-OS-Distribution"
     INSPECTION_METADATA_PRODUCT_NAME = "InspectionMetadata-Product-Name"
+    INSPECTION_METADATA_PARTIAL_RESULT = "InspectionMetadata-Partial-Result"

--- a/tests/inspection_tests.py
+++ b/tests/inspection_tests.py
@@ -157,6 +157,7 @@ header_to_json_mappings = {"os":"InspectionMetadata-Operating-System",
                 "os_distribution":"InspectionMetadata-OS-Distribution", 
                 "os_product_name":"InspectionMetadata-Product-Name",
                 "os_disk_configuration":"InspectionMetadata-Disk-Configuration",
+                "partial_result":"InspectionMetadata-Partial-Result",
                 "expected_timeout":"KeepAliveThread-Timeout-In-Mins",
                 "content_type":"Content-Type",
                 "content_length":"Content-Length"}

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -12,6 +12,7 @@
       "os_product_name": "CentOS Linux release 7.0.1406 (Core)",
       "os_disk_configuration": "Standard",
       "expected_timeout": "19",
+      "partial_result": "false",
       "files_present": [ "/device_0/etc/fstab", "/device_0/etc/hostname", "/device_0/etc/os-release", "/device_0/var/log/yum.log", "/device_0/var/log/waagent.log", "/device_0/var/log/messages", "diskinfo.txt" ]
     },
     {
@@ -24,6 +25,7 @@
       "os_product_name": "",
       "os_disk_configuration": "Standard",
       "expected_timeout": "19",
+      "partial_result": "false",
       "files_present": [ "/device_1/system-data/etc/ssh/sshd_config", "/device_1/system-data/var/log/cloud-init.log", "/device_1/system-data/var/log/dmesg" ]
     },
     {
@@ -36,6 +38,7 @@
       "os_product_name": "",
       "os_disk_configuration": "Standard",
       "expected_timeout": "19",
+      "partial_result": "false",
       "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
     },
     {
@@ -48,6 +51,7 @@
       "os_product_name": "FreeBSD 10.3-RELEASE (GENERIC) #2 d912ed6(10.3.0_hyperv): Thu May 19 09:20:45 CST 2016",
       "os_disk_configuration": "Standard",
       "expected_timeout": "19",
+      "partial_result": "false",
       "files_present": [ "/device_0/etc/rc.conf", "/device_0/etc/fstab", "/device_0/var/log/waagent.log", "/device_0/var/log/auth.log", "/device_0/boot/loader.conf" ]
     },
     {
@@ -60,6 +64,7 @@
       "os_product_name": "",
       "os_disk_configuration": "Standard",
       "expected_timeout": "19",
+      "partial_result": "false",
       "files_present": [ "/device_0/Windows/Setup/State/State.ini", "/device_0/Windows/Panther/WaSetup.xml" ],
       "file_content":{"/device_0/Windows/Setup/State/State.ini":"IMAGE_STATE_COMPLETE"}
     },
@@ -183,6 +188,7 @@
       "os_disk_configuration": "Standard",
       "timeout_override": "1",
       "expected_timeout": "1",
+      "partial_result": "true",
       "files_present": [ "/diskinfo.txt","/device_0/Windows/System32/winevt/Logs/System.evtx", "/device_0/Windows/System32/winevt/Logs/Application.evtx", "/device_0/Windows/Panther/UnattendGC/setupact.log", "/device_0/Windows/Panther/WaSetup.log", "/device_0/Windows/Panther/WaSetup.xml", "/device_0/WindowsAzure/Logs/WaAppAgent.log","/device_0/WindowsAzure/Logs/AggregateStatus/aggregatestatus.json", "/device_0/Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/1.6.4.0/RuntimeSettings/0.settings" ]
     },
     {


### PR DESCRIPTION
Adding new response header "InspectionMetadata-Partial-Result" to indicate if the inspection was partial or full. Previously, ACIS Extension was checking if the inspection zip file has the substring "partial" in file name to determine if result was partial. This method doesn't work when the result is uploaded by back end inspection web service to storage blob directly. The response header value is also slightly clearer and more deterministic. 