### PR TITLE
Add new path for extension logs

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -103,6 +103,7 @@ File Path | Manifest
 /var/log/azure/Microsoft.OSTCExtensions.LinuxDiagnostic/\*/mdsd.\* | servicefabric 
 /var/log/azure/Microsoft.\*LinuxDiagnostic/\*/\* | lad 
 /var/log/azure/\* | site-recovery, workloadbackup 
+/var/log/azure/\*/\* | agents, diagnostic 
 /var/log/azure/\*/\*/\* | agents, diagnostic 
 /var/log/azure/custom-script/handler.log | agents, diagnostic 
 /var/log/boot\* | diagnostic, eg, normal 
@@ -375,4 +376,4 @@ File Path | Manifest
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal 
 /unattend.xml | diagnostic, eg, normal 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-12-13 12:00:54.295729`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-01-08 10:18:43.280677`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -78,6 +78,7 @@ agents | copy | /var/log/waagent\*
 agents | copy | /var/log/dmesg\*
 agents | copy | /var/log/syslog\*
 agents | copy | /var/log/auth\*
+agents | copy | /var/log/azure/\*/\*
 agents | copy | /var/log/azure/\*/\*/\*
 agents | copy | /var/log/azure/custom-script/handler.log
 agents | copy | /var/lib/waagent/\*.xml
@@ -126,6 +127,7 @@ diagnostic | copy | /var/log/cloud-init\*
 diagnostic | copy | /var/log/boot\*
 diagnostic | copy | /var/log/auth\*
 diagnostic | copy | /var/log/secure\*
+diagnostic | copy | /var/log/azure/\*/\*
 diagnostic | copy | /var/log/azure/\*/\*/\*
 diagnostic | copy | /var/log/azure/custom-script/handler.log
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
@@ -929,4 +931,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2018-12-13 12:00:54.295729`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-01-08 10:18:43.280677`*

--- a/pyServer/manifests/linux/agents
+++ b/pyServer/manifests/linux/agents
@@ -14,6 +14,7 @@ copy,/var/log/waagent*
 copy,/var/log/dmesg*
 copy,/var/log/syslog*
 copy,/var/log/auth*
+copy,/var/log/azure/*/*
 copy,/var/log/azure/*/*/*
 copy,/var/log/azure/custom-script/handler.log
 echo,

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -43,6 +43,7 @@ copy,/var/log/cloud-init*
 copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*
+copy,/var/log/azure/*/*
 copy,/var/log/azure/*/*/*
 copy,/var/log/azure/custom-script/handler.log
 echo,


### PR DESCRIPTION
The VM Agent v2.2.32  changed the location of the extension logs from, for example,

    /var/log/azure/Microsoft.OSTCExtensions.VMAccessForLinux/1.4.7/extension.log
to
     /var/log/azure/Microsoft.OSTCExtensions.VMAccessForLinux/extension.log

Adding new path to capture logs from older and newer agents.