### PR TITLE
Remove case sensitivity for Windows os paths

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -265,9 +265,8 @@ File Path | Manifest
 /Windows/INF/netcfg\*.\*etl | diagnostic, windowsupdate 
 /Windows/INF/setupapi.\*.log | windowsupdate 
 /Windows/INF/setupapi.dev.log | diagnostic 
-/Windows/Inf/netcfg\*.\*etl | diagnostic, normal, windowsupdate 
-/Windows/Inf/setupapi.\*.log | windowsupdate 
-/Windows/Inf/setupapi.dev.log | diagnostic, normal 
+/Windows/Inf/netcfg\*.\*etl | normal 
+/Windows/Inf/setupapi.dev.log | normal 
 /Windows/Logs/CBS/\*.cab | windowsupdate 
 /Windows/Logs/CBS/\*.log | windowsupdate 
 /Windows/Logs/DISM/\*.log | windowsupdate 
@@ -398,9 +397,6 @@ File Path | Manifest
 /Windows/debug/dcpromoui.log | diagnostic, eg, normal, windowsupdate 
 /Windows/debug/mrt.log | diagnostic, eg, normal, windowsupdate 
 /Windows/debug/netlogon.log | diagnostic, eg, normal, windowsupdate 
-/Windows/inf/netcfg\*.\*etl | diagnostic, windowsupdate 
-/Windows/inf/setupapi.\*.log | windowsupdate 
-/Windows/inf/setupapi.dev.log | diagnostic 
 /Windows/servicing/sessions/sessions.xml | windowsupdate 
 /Windows/system32/winevt/Logs/Operations Manager.evtx | monitor-mgmt 
 /Windows/windowsupdate\*.log | windowsupdate 
@@ -454,4 +450,4 @@ File Path | Manifest
 /WindowsUpdateVerbose.etl | windowsupdate 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-02-27 09:55:01.377620`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-02-27 23:14:57.665432`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -496,11 +496,7 @@ diagnostic | copy | /Windows/System32/Sysprep/Panther/setuperr.log
 diagnostic | copy | /Windows/System32/Sysprep/Panther/IE/setuperr.log
 diagnostic | copy | /Windows/System32/Sysprep/Sysprep_succeeded.tag
 diagnostic | copy | /Windows/INF/netcfg\*.\*etl
-diagnostic | copy | /Windows/Inf/netcfg\*.\*etl
-diagnostic | copy | /Windows/inf/netcfg\*.\*etl
 diagnostic | copy | /Windows/INF/setupapi.dev.log
-diagnostic | copy | /Windows/Inf/setupapi.dev.log
-diagnostic | copy | /Windows/inf/setupapi.dev.log
 diagnostic | copy | /Windows/debug/netlogon.log
 diagnostic | copy | /Windows/debug/NetSetup.LOG
 diagnostic | copy | /Windows/debug/mrt.log
@@ -1010,11 +1006,7 @@ windowsupdate | copy | /Windows/System32/Sysprep/Panther/setuperr.log
 windowsupdate | copy | /Windows/System32/Sysprep/Panther/IE/setuperr.log
 windowsupdate | copy | /Windows/System32/Sysprep/Sysprep_succeeded.tag
 windowsupdate | copy | /Windows/INF/netcfg\*.\*etl
-windowsupdate | copy | /Windows/Inf/netcfg\*.\*etl
-windowsupdate | copy | /Windows/inf/netcfg\*.\*etl
 windowsupdate | copy | /Windows/INF/setupapi.\*.log
-windowsupdate | copy | /Windows/Inf/setupapi.\*.log
-windowsupdate | copy | /Windows/inf/setupapi.\*.log
 windowsupdate | copy | /Windows/debug/netlogon.log
 windowsupdate | copy | /Windows/debug/NetSetup.LOG
 windowsupdate | copy | /Windows/debug/mrt.log
@@ -1200,4 +1192,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-02-27 09:55:01.377620`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-02-27 23:14:57.665432`*

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -438,6 +438,11 @@ class GuestFishWrapper:
                                 opCommand = str(opList[0]).lower().strip()
                                 opParam1 = pathPrefix + opList[1].strip()
 
+                                if (osType.lower() == "windows"):
+                                    opParamWin = guestfish.case_sensitive_path(opParam1)
+                                    if (opParamWin is not None):
+                                        opParam1 = opParamWin
+
                                 if opCommand=="echo":
                                     self.WriteToResultFile(operationOutFile, opParam1)
                                 elif opCommand=="ll":

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -80,11 +80,7 @@ copy,/Windows/System32/Sysprep/Sysprep_succeeded.tag
 
 echo,### Plug and Play ###
 copy,/Windows/INF/netcfg*.*etl
-copy,/Windows/Inf/netcfg*.*etl
-copy,/Windows/inf/netcfg*.*etl
 copy,/Windows/INF/setupapi.dev.log
-copy,/Windows/Inf/setupapi.dev.log
-copy,/Windows/inf/setupapi.dev.log
 
 echo,### Active Directory domain join ###
 copy,/Windows/debug/netlogon.log

--- a/pyServer/manifests/windows/windowsupdate
+++ b/pyServer/manifests/windows/windowsupdate
@@ -82,11 +82,7 @@ copy,/Windows/System32/Sysprep/Sysprep_succeeded.tag
 
 echo,### Plug and Play ###
 copy,/Windows/INF/netcfg*.*etl
-copy,/Windows/Inf/netcfg*.*etl
-copy,/Windows/inf/netcfg*.*etl
 copy,/Windows/INF/setupapi.*.log
-copy,/Windows/Inf/setupapi.*.log
-copy,/Windows/inf/setupapi.*.log
 
 echo,### Active Directory domain join ###
 copy,/Windows/debug/netlogon.log


### PR DESCRIPTION
* For os type 'Windows' use "case_sensitive_path" function to remove the case sensitivity while looking for the path in disk.

* Remove duplicate paths with different case from manifest (windows/diagnostics), which are added to prevent "File not found"