### PR TITLE
Use latest libguestfs version from official upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # The libguestfs service provides a way to extract log files from a SAS uri of an
 # Azure blob as a zip archive.
  
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # package dependencies
 COPY conf/sources.list /etc/apt/sources.list
@@ -12,6 +12,10 @@ RUN apt-get update \
     autoconf \
     git \
     nginx \
+    libjansson-dev \
+    ocaml \
+    libhivex-ocaml \
+    libhivex-ocaml-dev \
     python3-pip \
     libssl-dev \
  && DEBIAN_FRONTEND=noninteractive apt-get build-dep -y \
@@ -20,12 +24,12 @@ RUN apt-get update \
 # Install Credential Scanner dependencies
 WORKDIR /
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | tee /etc/apt/sources.list.d/mono-official.list
+RUN echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-official.list
 RUN apt-get update && apt-get install -y mono-complete
 
 # patched libguestfs
 WORKDIR /
-RUN git clone https://github.com/craigwiand/libguestfs.git
+RUN git clone https://github.com/chintanrp/libguestfs.git
 WORKDIR /libguestfs
 RUN ./autogen.sh \
  && make ; rm -f po-docs/podfiles; make -C po-docs update-po 

--- a/conf/sources.list
+++ b/conf/sources.list
@@ -8,50 +8,50 @@
 
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial main restricted
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial main restricted
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic main restricted
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic main restricted
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial-updates main restricted
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic-updates main restricted
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
 ## review or updates from the Ubuntu security team.
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial universe
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial universe
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial-updates universe
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial-updates universe
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic universe
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic universe
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic-updates universe
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic-updates universe
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
 ## team, and may not be under a free licence. Please satisfy yourself as to 
 ## your rights to use the software. Also, please note that software in 
 ## multiverse WILL NOT receive any review or updates from the Ubuntu
 ## security team.
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial multiverse
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial multiverse
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial-updates multiverse
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial-updates multiverse
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic multiverse
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic multiverse
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic-updates multiverse
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic-updates multiverse
 
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
 ## Also, please note that software in backports WILL NOT receive any review
 ## or updates from the Ubuntu security team.
-deb http://azure.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
-deb-src http://azure.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb http://azure.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
+deb-src http://azure.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
 
-deb http://security.ubuntu.com/ubuntu xenial-security main restricted
-deb-src http://security.ubuntu.com/ubuntu xenial-security main restricted
-deb http://security.ubuntu.com/ubuntu xenial-security universe
-deb-src http://security.ubuntu.com/ubuntu xenial-security universe
-deb http://security.ubuntu.com/ubuntu xenial-security multiverse
-deb-src http://security.ubuntu.com/ubuntu xenial-security multiverse
+deb http://security.ubuntu.com/ubuntu bionic-security main restricted
+deb-src http://security.ubuntu.com/ubuntu bionic-security main restricted
+deb http://security.ubuntu.com/ubuntu bionic-security universe
+deb-src http://security.ubuntu.com/ubuntu bionic-security universe
+deb http://security.ubuntu.com/ubuntu bionic-security multiverse
+deb-src http://security.ubuntu.com/ubuntu bionic-security multiverse
 
 ## Uncomment the following two lines to add software from Canonical's
 ## 'partner' repository.
 ## This software is not part of Ubuntu, but is offered by Canonical and the
 ## respective vendors as a service to Ubuntu users.
-# deb http://archive.canonical.com/ubuntu xenial partner
-# deb-src http://archive.canonical.com/ubuntu xenial partner
+# deb http://archive.canonical.com/ubuntu bionic partner
+# deb-src http://archive.canonical.com/ubuntu bionic partner


### PR DESCRIPTION
 - Change Dockerfile to use the fork which contain merge of Official libguest upstream and fork - https://github.com/CraigWiand/libguestfs
(This will be change to official libguest upstream after "query string" changes merge to official branch)
- Updates in Dockerfile needed for above change - upgrade base OS ubuntu version to 18.04, add required new packages