### PR TITLE
Add netplan config in diagnostic and eg manifests for Ubuntu 18.04

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -49,6 +49,7 @@ File Path | Manifest
 /etc/hive2/conf/\* | hdinsight 
 /etc/hostname | agents, diagnostic, eg, genspec, lad, site-recovery, workloadbackup 
 /etc/hosts | hdinsight 
+/etc/netplan/50-cloud-init.yaml | diagnostic, eg 
 /etc/network/interfaces | diagnostic, eg 
 /etc/network/interfaces.d/\*.cfg | diagnostic, eg 
 /etc/nsswitch.conf | diagnostic 
@@ -460,4 +461,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-05-01 08:50:32.698813`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-05-10 01:42:38.246644`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -110,6 +110,7 @@ diagnostic | copy | /etc/HOSTNAME
 diagnostic | copy | /etc/hostname
 diagnostic | copy | /etc/network/interfaces
 diagnostic | copy | /etc/network/interfaces.d/\*.cfg
+diagnostic | copy | /etc/netplan/50-cloud-init.yaml
 diagnostic | copy | /etc/nsswitch.conf
 diagnostic | copy | /etc/resolv.conf
 diagnostic | copy | /etc/sysconfig/iptables
@@ -164,6 +165,7 @@ eg | copy | /etc/HOSTNAME
 eg | copy | /etc/hostname
 eg | copy | /etc/network/interfaces
 eg | copy | /etc/network/interfaces.d/\*.cfg
+eg | copy | /etc/netplan/50-cloud-init.yaml
 eg | copy | /etc/resolv.conf
 eg | copy | /etc/sysconfig/iptables
 eg | copy | /etc/sysconfig/network
@@ -1205,4 +1207,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-05-01 08:50:32.698813`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-05-10 01:42:38.246644`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -14,6 +14,7 @@ copy,/etc/HOSTNAME
 copy,/etc/hostname
 copy,/etc/network/interfaces
 copy,/etc/network/interfaces.d/*.cfg
+copy,/etc/netplan/50-cloud-init.yaml
 copy,/etc/nsswitch.conf
 copy,/etc/resolv.conf
 copy,/etc/sysconfig/iptables

--- a/pyServer/manifests/linux/eg
+++ b/pyServer/manifests/linux/eg
@@ -13,6 +13,7 @@ copy,/etc/HOSTNAME
 copy,/etc/hostname
 copy,/etc/network/interfaces
 copy,/etc/network/interfaces.d/*.cfg
+copy,/etc/netplan/50-cloud-init.yaml
 copy,/etc/resolv.conf
 copy,/etc/sysconfig/iptables
 copy,/etc/sysconfig/network


### PR DESCRIPTION
For Ubuntu 18.04  /etc/network info- the ifup and ifdown functionality is deprecated and it now uses netplan