### PR TITLE
Removing Registered catalog from manifest

### DIFF
--- a/pyServer/manifests/windows/workloadbackup
+++ b/pyServer/manifests/windows/workloadbackup
@@ -7,7 +7,6 @@ copy,/Windows/System32/Tasks/Microsoft/IaaSWorkloadBackup/*
 
 echo,### Additional Event Logs ###
 copy,/Program Files/Azure Workload Backup/Catalog/InquiryCatalog/*/*.bin
-copy,/Program Files/Azure Workload Backup/Catalog/RegisteredObjectInfoCatalog/*/*.bin
 copy,/Program Files/Azure Workload Backup/Catalog/WorkloadExtDatasourceCatalog/*/*.bin
 copy,/Program Files/Azure Workload Backup/Catalog/WorkloadSchedules/*/*.bin
 copy,/Program Files/Azure Workload Backup/Catalog/SyncObjectsCatalog/DatasourceSyncTable/*.bin


### PR DESCRIPTION
Removing Registered catalog from manifest to add the functionality to retrieve logs via ASC