### PR TITLE
adding AADLogs to Diagnostics

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -418,6 +418,7 @@ File Path | Manifest
 /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json | agents, diagnostic, eg, min-diagnostic, normal, windowsupdate, workloadbackup 
 /WindowsAzure/Logs/AppAgentRuntime.log | agents, diagnostic, eg, normal, windowsupdate, workloadbackup 
 /WindowsAzure/Logs/MonitoringAgent.log | agents, diagnostic, eg, normal, servicefabric, windowsupdate 
+/WindowsAzure/Logs/Plugins/Microsoft.Azure.ActiveDirectory.AADLoginForWindows/\*/\*.l<br>og | diagnostic 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/Diagnostics<br>Plugin.log | agents, diagnostic, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/Diagnostics<br>PluginLauncher.log | agents, diagnostic, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/\*/Configur<br>ation/Checkpoint.txt | agents, diagnostic, normal, servicefabric, windowsupdate 
@@ -470,4 +471,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-08-08 10:44:09.800455`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-09-17 13:21:59.666731`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -627,6 +627,7 @@ diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.ManagedIdentity.Managed
 diagnostic | copy | /WindowsAzure/GuestAgent\*/CommonAgentConfig.config
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Compute.CustomScriptExtension/\*/\*.log
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.CPlat.Core.RunCommandWindows/\*/\*.log
+diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.ActiveDirectory.AADLoginForWindows/\*/\*.l<br>og
 diagnostic | copy | /Windows/servicing/sessions/sessions.xml
 diagnostic | diskinfo | 
 eg | copy | /Windows/System32/winevt/Logs/System.evtx
@@ -1232,4 +1233,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-08-08 10:44:09.800455`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-09-17 13:21:59.666731`*

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -192,6 +192,7 @@ copy,/WindowsAzure/Logs/Plugins/Microsoft.ManagedIdentity.ManagedIdentityExtensi
 copy,/WindowsAzure/GuestAgent*/CommonAgentConfig.config
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Compute.CustomScriptExtension/*/*.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.CPlat.Core.RunCommandWindows/*/*.log
+copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.ActiveDirectory.AADLoginForWindows/*/*.log
 
 echo,### Servicing ###
 copy,/Windows/servicing/sessions/sessions.xml


### PR DESCRIPTION

From: David Everett 
Sent: Thursday, September 12, 2019 4:51 PM
To: Gabriela Limoli <Gabriela.Limoli@microsoft.com>
Cc: Johnny Coleman <johnnyc@microsoft.com>; Kari Lacobee <kalaco@microsoft.com>
Subject: Inspect Iaas Disk Diagnostic not capturing AADLoginForWindows agent logs

Hi Gabriella,

The Inspect Iaas Disk diagnostic collects logs from the AADLoginForLinux VM, but its not capturing the logs from AADLoginForWindows.

•	Can we have this diagnostic capture any log that is greater than 4k under C:\WindowsAzure\Logs\Plugins\Microsoft.Azure.ActiveDirectory.AADLoginForWindows\0.3.1.0?
o	Can we have it find the latest version folder in the path in the event this changes over time?

Thanks,
David
