### PR TITLE
Set Azure Storage Blob package version to 1.4.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - cat ~/docker_build.txt
     - stage: deploy  
       install: 
-        - pip3 install azure-storage-blob
+        - pip3 install azure-storage-blob==1.4.0
         - echo "$REG_PASS" | docker login -u $REG_USER $AZ_REGISTRY --password-stdin
         - mkdir $HOME/azdis_ssl
         - openssl req -x509 -newkey rsa:2048 -keyout $HOME/azdis_ssl/azdis_private.rsa -out $HOME/azdis_ssl/azdis_public.crt -days 365 -nodes -subj "/CN=localhost"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY pyServer/manifests/ /etc/azdis/
 RUN ln -s -f /usr/bin/python3 /usr/bin/python
 
 # Install AppInsights 
-RUN pip3 install azure-storage-blob
+RUN pip3 install azure-storage-blob==1.4.0
 RUN pip3 install applicationinsights
 
 # Expose port 8080 for nginx


### PR DESCRIPTION
Set Azure Storage Blob package version to 1.4.0 to prevent it to pick default latest version, which is not compatible. 