### PR TITLE
Update hdinsight manifest with log files

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -118,6 +118,9 @@ File Path | Manifest
 /var/lib/waagent/waagent_status.json | agents, diagnostic 
 /var/lib/wicked/lease-eth0-dhcp-ipv4.xml | diagnostic, eg 
 /var/log/AzureRcmCli.log | site-recovery 
+/var/log/ambari-agent/ambari-agent.log | hdinsight 
+/var/log/ambari-server/ambari-audit.log | hdinsight 
+/var/log/ambari-server/ambari-server.log | hdinsight 
 /var/log/auth\* | agents, diagnostic, eg, normal 
 /var/log/azure-vnet\* | aks 
 /var/log/azure/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode/\*.\*/CommandExec<br>ution.log | servicefabric 
@@ -139,6 +142,9 @@ File Path | Manifest
 /var/log/dpkg.log | servicefabric 
 /var/log/dpkg\* | diagnostic, eg, normal 
 /var/log/evtcollforw\*.log | site-recovery 
+/var/log/hadoop-yarn/yarn/\* | hdinsight 
+/var/log/hive/hivemetastore.log | hdinsight 
+/var/log/hive/hiveserver2.log | hdinsight 
 /var/log/journal/\*/\* | aks 
 /var/log/kern.log | servicefabric 
 /var/log/kern\* | diagnostic, eg, normal 
@@ -472,4 +478,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-12-12 22:36:57.040189`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-01-15 21:17:22.178240`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -142,7 +142,7 @@ File Path | Manifest
 /var/log/dpkg.log | servicefabric 
 /var/log/dpkg\* | diagnostic, eg, normal 
 /var/log/evtcollforw\*.log | site-recovery 
-/var/log/hadoop-yarn/yarn/\* | hdinsight 
+/var/log/hadoop-yarn/yarn/\*.log | hdinsight 
 /var/log/hive/hivemetastore.log | hdinsight 
 /var/log/hive/hiveserver2.log | hdinsight 
 /var/log/journal/\*/\* | aks 
@@ -478,4 +478,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-01-15 21:17:22.178240`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-01-15 21:37:51.359351`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -211,6 +211,12 @@ hdinsight | copy | /etc/storm/conf/\*
 hdinsight | copy | /etc/hive2/conf/\*
 hdinsight | copy | /var/lib/.jupyter/jupyter_notebook_config.py
 hdinsight | copy | /etc/hosts
+hdinsight | copy | /var/log/ambari-server/ambari-server.log
+hdinsight | copy | /var/log/ambari-server/ambari-audit.log
+hdinsight | copy | /var/log/ambari-agent/ambari-agent.log
+hdinsight | copy | /var/log/hadoop-yarn/yarn/\*
+hdinsight | copy | /var/log/hive/hiveserver2.log
+hdinsight | copy | /var/log/hive/hivemetastore.log
 lad | list | /var/log
 lad | list | /etc/udev/rules.d
 lad | copy | /etc/HOSTNAME
@@ -1238,4 +1244,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2019-12-12 22:36:57.040189`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-01-15 21:17:22.178240`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -214,7 +214,7 @@ hdinsight | copy | /etc/hosts
 hdinsight | copy | /var/log/ambari-server/ambari-server.log
 hdinsight | copy | /var/log/ambari-server/ambari-audit.log
 hdinsight | copy | /var/log/ambari-agent/ambari-agent.log
-hdinsight | copy | /var/log/hadoop-yarn/yarn/\*
+hdinsight | copy | /var/log/hadoop-yarn/yarn/\*.log
 hdinsight | copy | /var/log/hive/hiveserver2.log
 hdinsight | copy | /var/log/hive/hivemetastore.log
 lad | list | /var/log
@@ -1244,4 +1244,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-01-15 21:17:22.178240`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-01-15 21:37:51.359351`*

--- a/pyServer/manifests/linux/hdinsight
+++ b/pyServer/manifests/linux/hdinsight
@@ -17,6 +17,6 @@ echo,### HDInsight Log Files ###
 copy,/var/log/ambari-server/ambari-server.log
 copy,/var/log/ambari-server/ambari-audit.log
 copy,/var/log/ambari-agent/ambari-agent.log
-copy,/var/log/hadoop-yarn/yarn/*
+copy,/var/log/hadoop-yarn/yarn/*.log
 copy,/var/log/hive/hiveserver2.log
 copy,/var/log/hive/hivemetastore.log

--- a/pyServer/manifests/linux/hdinsight
+++ b/pyServer/manifests/linux/hdinsight
@@ -12,3 +12,11 @@ copy,/var/lib/.jupyter/jupyter_notebook_config.py
 
 echo,### HDInsight Host Files ###
 copy,/etc/hosts
+
+echo,### HDInsight Log Files ###
+copy,/var/log/ambari-server/ambari-server.log
+copy,/var/log/ambari-server/ambari-audit.log
+copy,/var/log/ambari-agent/ambari-agent.log
+copy,/var/log/hadoop-yarn/yarn/*
+copy,/var/log/hive/hiveserver2.log
+copy,/var/log/hive/hivemetastore.log


### PR DESCRIPTION
Add a minimal set of log files to hdinsight manifest
to be retrieved along with the existing set of
configuration files.