### PR TITLE
Update OMS [monitor-mgmt] Manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -55,11 +55,11 @@ File Path | Manifest
 /etc/network/interfaces.d/\*.cfg | diagnostic, eg 
 /etc/nsswitch.conf | diagnostic 
 /etc/opt/microsoft/omsagent/LAD/conf/omsagent.d/\* | lad 
+/etc/opt/microsoft/omsagent/\*/conf/\*.conf | monitor-mgmt 
 /etc/opt/microsoft/omsagent/\*/conf/omsagent.d/\*.conf | monitor-mgmt 
-/etc/opt/microsoft/omsagent/conf/omsagent.conf | monitor-mgmt 
-/etc/opt/omi/conf/omsconfig/agentid | monitor-mgmt 
 /etc/opt/omi/conf/omsconfig/configuration/\*.mof | monitor-mgmt 
 /etc/resolv.conf | diagnostic, eg 
+/etc/rsyslog.d/95-omsagent.conf | monitor-mgmt 
 /etc/spark/conf/\* | hdinsight 
 /etc/ssh/sshd_config | diagnostic, normal 
 /etc/storm/conf/\* | hdinsight 
@@ -70,6 +70,7 @@ File Path | Manifest
 /etc/sysconfig/network-scripts/route-eth\* | diagnostic, eg 
 /etc/sysconfig/network/ifcfg-eth\* | diagnostic, eg 
 /etc/sysconfig/network/routes | diagnostic, eg 
+/etc/syslog-ng/syslog-ng.conf | monitor-mgmt 
 /etc/ufw/ufw.conf | diagnostic, eg 
 /etc/waagent.conf | agents, diagnostic, eg, site-recovery, workloadbackup 
 /opt/microsoft/servicefabric/bin/Fabric/Fabric.Code/Fabric | servicefabric 
@@ -102,6 +103,8 @@ File Path | Manifest
 /var/lib/waagent/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode-\*/Service/curr<br>ent.config | servicefabric 
 /var/lib/waagent/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode-\*/config/\*.se<br>ttings | servicefabric 
 /var/lib/waagent/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode-\*/heartbeat.lo<br>g | servicefabric, servicefabric 
+/var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-\*/config/\* | monitor-mgmt 
+/var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-\*/status/\* | monitor-mgmt 
 /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-\*/xmlCfg.xml | servicefabric 
 /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/config/\*.settings | lad 
 /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/status/\*.status | lad 
@@ -124,6 +127,7 @@ File Path | Manifest
 /var/log/auth\* | agents, diagnostic, eg, normal 
 /var/log/azure-vnet\* | aks 
 /var/log/azure/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode/\*.\*/CommandExec<br>ution.log | servicefabric 
+/var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/\*.log | monitor-mgmt 
 /var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/\*/\*.log | monitor-mgmt 
 /var/log/azure/Microsoft.OSTCExtensions.LinuxDiagnostic/\*/mdsd.\* | servicefabric 
 /var/log/azure/Microsoft.\*LinuxDiagnostic/\*/\* | lad 
@@ -166,11 +170,12 @@ File Path | Manifest
 /var/log/waagent\*.log | monitor-mgmt 
 /var/log/yum\* | diagnostic, eg, normal 
 /var/opt/microsoft/omsagent/LAD/log/\* | lad 
-/var/opt/microsoft/omsagent/\*/log/omsagent.log | monitor-mgmt 
+/var/opt/microsoft/omsagent/\*/log/omsagent\* | monitor-mgmt 
 /var/opt/microsoft/omsagent/\*/run/automationworker/omsupdatemgmt.log | monitor-mgmt 
 /var/opt/microsoft/omsagent/run/automationworker/worker.log | monitor-mgmt 
 /var/opt/microsoft/omsconfig/omsconfig.log | monitor-mgmt 
 /var/opt/microsoft/omsconfig/omsconfigdetailed.log | monitor-mgmt 
+/var/opt/microsoft/scx/log/omsagent/scx.log | monitor-mgmt 
 /var/opt/microsoft/scx/log/scx.log | monitor-mgmt 
 /var/opt/omi/log/\*.log | monitor-mgmt 
 /var/run/azure-vnet\* | aks 
@@ -480,4 +485,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-02-06 19:01:59.770932`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-02-13 18:01:05.179049`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -232,18 +232,23 @@ lad | copy | /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/config/\*.settings
 lad | copy | /var/lib/waagent/Microsoft.\*LinuxDiagnostic\*/xmlCfg.xml
 lad | copy | /etc/opt/microsoft/omsagent/LAD/conf/omsagent.d/\*
 lad | copy | /var/opt/microsoft/omsagent/LAD/log/\*
-monitor-mgmt | copy | /var/opt/microsoft/omsagent/\*/log/omsagent.log
+monitor-mgmt | copy | /var/opt/microsoft/omsagent/\*/log/omsagent\*
 monitor-mgmt | copy | /var/opt/microsoft/omsconfig/omsconfig.log
 monitor-mgmt | copy | /var/opt/microsoft/omsconfig/omsconfigdetailed.log
-monitor-mgmt | copy | /etc/opt/microsoft/omsagent/conf/omsagent.conf
+monitor-mgmt | copy | /etc/opt/microsoft/omsagent/\*/conf/\*.conf
 monitor-mgmt | copy | /etc/opt/microsoft/omsagent/\*/conf/omsagent.d/\*.conf
-monitor-mgmt | copy | /etc/opt/omi/conf/omsconfig/agentid
 monitor-mgmt | copy | /var/log/messages\*
 monitor-mgmt | copy | /var/log/syslog\*
+monitor-mgmt | copy | /etc/rsyslog.d/95-omsagent.conf
+monitor-mgmt | copy | /etc/syslog-ng/syslog-ng.conf
 monitor-mgmt | copy | /var/opt/microsoft/scx/log/scx.log
+monitor-mgmt | copy | /var/opt/microsoft/scx/log/omsagent/scx.log
 monitor-mgmt | copy | /var/opt/omi/log/\*.log
 monitor-mgmt | copy | /var/log/waagent\*.log
+monitor-mgmt | copy | /var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/\*.log
 monitor-mgmt | copy | /var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/\*/\*.log
+monitor-mgmt | copy | /var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-\*/config/\*
+monitor-mgmt | copy | /var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-\*/status/\*
 monitor-mgmt | copy | /var/opt/microsoft/omsagent/\*/run/automationworker/omsupdatemgmt.log
 monitor-mgmt | copy | /var/opt/microsoft/omsagent/run/automationworker/worker.log
 monitor-mgmt | copy | /tmp/omsagent\*.tgz
@@ -1246,4 +1251,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-02-06 19:01:59.770932`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-02-13 18:01:05.179049`*

--- a/pyServer/manifests/linux/monitor-mgmt
+++ b/pyServer/manifests/linux/monitor-mgmt
@@ -1,39 +1,46 @@
-echo,#Microsoft Monitoring Agent for Linux Log File
-copy,/var/opt/microsoft/omsagent/*/log/omsagent.log
+echo,# OMS Agent for Linux Log File
+copy,/var/opt/microsoft/omsagent/*/log/omsagent*
 
-echo,#Microsoft Monitoring Agent Configuration Log File
+echo,# DSC Log File
 copy,/var/opt/microsoft/omsconfig/omsconfig.log
 copy,/var/opt/microsoft/omsconfig/omsconfigdetailed.log
 
-echo,#Microsoft Monitoring Agent Configuration File
-copy,/etc/opt/microsoft/omsagent/conf/omsagent.conf
+echo,# OMS Agent Configuration File
+copy,/etc/opt/microsoft/omsagent/*/conf/*.conf
 copy,/etc/opt/microsoft/omsagent/*/conf/omsagent.d/*.conf
 
-echo,#Microsoft Monitoring Agent Agent ID File
-copy,/etc/opt/omi/conf/omsconfig/agentid
-
-echo,#Syslog
+echo,# Syslog Log File
 copy,/var/log/messages*
 copy,/var/log/syslog*
 
-echo,#SCX Logs
-copy,/var/opt/microsoft/scx/log/scx.log
+echo,# Syslog Conf File
+copy,/etc/rsyslog.d/95-omsagent.conf
+copy,/etc/syslog-ng/syslog-ng.conf
 
-echo,#OMI Logs
+echo,# SCX Logs
+copy,/var/opt/microsoft/scx/log/scx.log
+copy,/var/opt/microsoft/scx/log/omsagent/scx.log
+
+echo,# OMI Logs
 copy,/var/opt/omi/log/*.log
 
-echo,#WAAgent Logs
+echo,# WAAgent Logs
 copy,/var/log/waagent*.log
 
-echo,#Microsoft Monitoring Agent Extension Logs
+echo,# OMS Agent Extension Logs
+copy,/var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/*.log
 copy,/var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/*/*.log
 
-echo,#Update Management Logs
+echo,# OMS Agent Extension Status File
+copy,/var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-*/config/*
+copy,/var/lib/waagent/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux-*/status/*
+
+echo,# Update Management Logs
 copy,/var/opt/microsoft/omsagent/*/run/automationworker/omsupdatemgmt.log
 copy,/var/opt/microsoft/omsagent/run/automationworker/worker.log
 
-echo,#Log Collector Tool Logs
+echo,# Log Collector Tool Logs
 copy,/tmp/omsagent*.tgz
 
-echo,#DSC Files
+echo,# DSC Configuration Files
 copy,/etc/opt/omi/conf/omsconfig/configuration/*.mof


### PR DESCRIPTION
Hi, I'm one of the owners for the OMS Agent and I wanted to tweak the manifest to be more in line with what we collect with our log collection tool (minus the scripts that are run with our tool, of course). 

In some ways it would be nice to amend the name to "oms" rather than "monitor-mgmt" but I understand if that is too drastic or complex to achieve. 