### PR TITLE
Optimize diagnostic manifest by removing two most expensive calls

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -421,6 +421,7 @@ File Path | Manifest
 /Windows/debug/dcpromoui.log | diagnostic, eg, normal, windowsupdate 
 /Windows/debug/mrt.log | diagnostic, eg, normal, windowsupdate 
 /Windows/debug/netlogon.log | diagnostic, eg, normal, windowsupdate 
+/Windows/memory.dmp | dump 
 /Windows/servicing/sessions/sessions.xml | diagnostic, windowsupdate 
 /Windows/system32/winevt/Logs/Operations Manager.evtx | monitor-mgmt 
 /Windows/windowsupdate\*.log | windowsupdate 
@@ -482,4 +483,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-02-27 17:38:29.168974`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 12:00:23.854247`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -421,7 +421,6 @@ File Path | Manifest
 /Windows/debug/dcpromoui.log | diagnostic, eg, normal, windowsupdate 
 /Windows/debug/mrt.log | diagnostic, eg, normal, windowsupdate 
 /Windows/debug/netlogon.log | diagnostic, eg, normal, windowsupdate 
-/Windows/memory.dmp | dump 
 /Windows/servicing/sessions/sessions.xml | diagnostic, windowsupdate 
 /Windows/system32/winevt/Logs/Operations Manager.evtx | monitor-mgmt 
 /Windows/windowsupdate\*.log | windowsupdate 
@@ -483,4 +482,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:13:39.772540`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -248,7 +248,7 @@ File Path | Manifest
 /Packages/Plugins/\*/\*/PackageInformation.txt | agents, diagnostic, normal, servicefabric, windowsupdate 
 /Packages/Plugins/\*/\*/RuntimeSettings/\*.settings | agents, diagnostic, normal, servicefabric, windowsupdate 
 /Packages/Plugins/\*/\*/Status/HeartBeat.Json | agents, diagnostic, normal, servicefabric, windowsupdate 
-/Packages/Plugins/\*/\*/Status/\*.status | agents, diagnostic, normal, servicefabric, windowsupdate 
+/Packages/Plugins/\*/\*/Status/\*.status | agents, normal, servicefabric, windowsupdate 
 /Packages/Plugins/\*/\*/config.txt | agents, diagnostic, normal, servicefabric, windowsupdate 
 /Program Files (x86)/Microsoft Azure Site Recovery/agent/AzureRcmCli.log | site-recovery, windowsupdate 
 /Program Files (x86)/Microsoft Azure Site Recovery/agent/evtcollforw\*.log | site-recovery, windowsupdate 
@@ -440,7 +440,7 @@ File Path | Manifest
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.Edp.NetworkWatcherAgentWind<br>ows/\*/\*.txt | agents, diagnostic, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/<br>\*/\*.log | agents, diagnostic, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/<br>\*/\*.txt | agents, diagnostic, normal, windowsupdate 
-/WindowsAzure/Logs/Plugins/Microsoft.Azure.RecoveryServices.VMSnapshot/\*/IaaSBcdrExt<br>ension\*.log | agents, diagnostic, normal, windowsupdate 
+/WindowsAzure/Logs/Plugins/Microsoft.Azure.RecoveryServices.VMSnapshot/\*/IaaSBcdrExt<br>ension\*.log | agents, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.Security.IaaSAntimalware/\*/AntimalwareCon<br>fig.log | agents, diagnostic, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.Security.Monitoring/\*/AsmExtension.log | agents, diagnostic, normal, windowsupdate 
 /WindowsAzure/Logs/Plugins/Microsoft.Azure.ServiceFabric.ServiceFabricNode/\*/FabricM<br>SIInstall\*.log | agents, diagnostic, normal, windowsupdate 
@@ -483,4 +483,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 12:00:23.854247`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 16:09:21.563523`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -483,4 +483,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 16:09:21.563523`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:13:39.772540`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -1249,4 +1249,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 16:09:21.563523`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:13:39.772540`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -645,6 +645,7 @@ diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.CPlat.Core.RunCommandWi
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.ActiveDirectory.AADLoginForWindows/\*/\*.l<br>og
 diagnostic | copy | /Windows/servicing/sessions/sessions.xml
 diagnostic | diskinfo | 
+dump | copy | /Windows/memory.dmp
 eg | copy | /Windows/System32/winevt/Logs/System.evtx
 eg | copy | /Windows/System32/winevt/Logs/Application.evtx
 eg | copy | /Windows/System32/winevt/Logs/Microsoft-ServiceFabric%4Admin.evtx
@@ -1250,4 +1251,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-02-27 17:38:29.168974`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 12:00:23.854247`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -643,7 +643,6 @@ diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.CPlat.Core.RunCommandWi
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.ActiveDirectory.AADLoginForWindows/\*/\*.l<br>og
 diagnostic | copy | /Windows/servicing/sessions/sessions.xml
 diagnostic | diskinfo | 
-dump | copy | /Windows/memory.dmp
 eg | copy | /Windows/System32/winevt/Logs/System.evtx
 eg | copy | /Windows/System32/winevt/Logs/Application.evtx
 eg | copy | /Windows/System32/winevt/Logs/Microsoft-ServiceFabric%4Admin.evtx
@@ -1249,4 +1248,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:13:39.772540`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -562,7 +562,6 @@ diagnostic | copy | /Packages/Plugins/\*/\*/config.txt
 diagnostic | copy | /Packages/Plugins/\*/\*/HandlerEnvironment.json
 diagnostic | copy | /Packages/Plugins/\*/\*/HandlerManifest.json
 diagnostic | copy | /Packages/Plugins/\*/\*/RuntimeSettings/\*.settings
-diagnostic | copy | /Packages/Plugins/\*/\*/Status/\*.status
 diagnostic | copy | /Packages/Plugins/\*/\*/Status/HeartBeat.Json
 diagnostic | copy | /Packages/Plugins/\*/\*/PackageInformation.txt
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/\*/Configur<br>ation/Checkpoint.txt
@@ -570,7 +569,6 @@ diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSD
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/\*/Configur<br>ation/MonAgentHost.\*.log
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/Diagnostics<br>Plugin.log
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/Diagnostics<br>PluginLauncher.log
-diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.RecoveryServices.VMSnapshot/\*/IaaSBcdrExt<br>ension\*.log
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Security.IaaSAntimalware/\*/AntimalwareCon<br>fig.log
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.Security.Monitoring/\*/AsmExtension.log
 diagnostic | copy | /WindowsAzure/Logs/Plugins/Microsoft.Azure.ServiceFabric.ServiceFabricNode/\*/FabricM<br>SIInstall\*.log
@@ -1251,4 +1249,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 12:00:23.854247`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-10 16:09:21.563523`*

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -112,7 +112,6 @@ copy,/Packages/Plugins/*/*/config.txt
 copy,/Packages/Plugins/*/*/HandlerEnvironment.json
 copy,/Packages/Plugins/*/*/HandlerManifest.json
 copy,/Packages/Plugins/*/*/RuntimeSettings/*.settings
-copy,/Packages/Plugins/*/*/Status/*.status
 copy,/Packages/Plugins/*/*/Status/HeartBeat.Json
 copy,/Packages/Plugins/*/*/PackageInformation.txt
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/*/*/Configuration/Checkpoint.txt
@@ -120,7 +119,6 @@ copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/*/*/
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/*/*/Configuration/MonAgentHost.*.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/*/DiagnosticsPlugin.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/*/DiagnosticsPluginLauncher.log
-copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.RecoveryServices.VMSnapshot/*/IaaSBcdrExtension*.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Security.IaaSAntimalware/*/AntimalwareConfig.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.Security.Monitoring/*/AsmExtension.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.ServiceFabric.ServiceFabricNode/*/FabricMSIInstall*.log

--- a/pyServer/manifests/windows/dump
+++ b/pyServer/manifests/windows/dump
@@ -1,0 +1,2 @@
+echo,### Memory Dump ###
+copy,/Windows/memory.dmp


### PR DESCRIPTION
Removed the two most expensive calls which are wildcards for infrequently used Windows guest agent  files that if needed, are already collected by the agents manifest.