### PR TITLE
Add HandlerState and HandlerStatus file to Inspect IaaS Disk Tool

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -25,6 +25,8 @@ File Path | Manifest
 /var/lib/waagent/Prod.\*.manifest.xml | agents, diagnostic 
 /var/lib/waagent/SharedConfig.xml | agents, diagnostic 
 /var/lib/waagent/\*.xml | agents 
+/var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
+/var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, genspec 
@@ -112,6 +114,8 @@ File Path | Manifest
 /var/lib/waagent/\*.agentsManifest | agents 
 /var/lib/waagent/\*.manifest.xml | diagnostic 
 /var/lib/waagent/\*.xml | agents, site-recovery, workloadbackup 
+/var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
+/var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/error.json | agents, diagnostic 
@@ -482,4 +486,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-04-14 23:06:00.867930`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -25,8 +25,6 @@ File Path | Manifest
 /var/lib/waagent/Prod.\*.manifest.xml | agents, diagnostic 
 /var/lib/waagent/SharedConfig.xml | agents, diagnostic 
 /var/lib/waagent/\*.xml | agents 
-/var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
-/var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, genspec 
@@ -114,8 +112,6 @@ File Path | Manifest
 /var/lib/waagent/\*.agentsManifest | agents 
 /var/lib/waagent/\*.manifest.xml | diagnostic 
 /var/lib/waagent/\*.xml | agents, site-recovery, workloadbackup 
-/var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
-/var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/error.json | agents, diagnostic 
@@ -486,4 +482,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-04-14 23:06:00.867930`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -25,6 +25,8 @@ File Path | Manifest
 /var/lib/waagent/Prod.\*.manifest.xml | agents, diagnostic 
 /var/lib/waagent/SharedConfig.xml | agents, diagnostic 
 /var/lib/waagent/\*.xml | agents 
+/var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
+/var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, genspec 
@@ -112,6 +114,8 @@ File Path | Manifest
 /var/lib/waagent/\*.agentsManifest | agents 
 /var/lib/waagent/\*.manifest.xml | diagnostic 
 /var/lib/waagent/\*.xml | agents, site-recovery, workloadbackup 
+/var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
+/var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
 /var/lib/waagent/error.json | agents, diagnostic 
@@ -482,4 +486,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-04-15 23:59:45.102914`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -20,8 +20,6 @@ agents | copy | /var/log/azure/\*/\*/\*
 agents | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
-agents | copy | /var/lib/waagent/\*/config/HandlerState
-agents | copy | /var/lib/waagent/\*/config/HandlerStatus
 agents | copy | /var/lib/waagent/GoalState.\*.xml
 agents | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 agents | copy | /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml
@@ -50,8 +48,6 @@ diagnostic | copy | /var/log/azure/\*/\*/\*
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
-diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
-diagnostic | copy | /var/lib/waagent/\*/config/HandlerStatus
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml
@@ -90,8 +86,6 @@ agents | copy | /var/lib/waagent/\*.xml
 agents | copy | /var/lib/waagent/waagent_status.json
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
-agents | copy | /var/lib/waagent/\*/config/HandlerState
-agents | copy | /var/lib/waagent/\*/config/HandlerStatus
 agents | copy | /var/lib/waagent/\*.agentsManifest
 agents | copy | /var/lib/waagent/error.json
 agents | copy | /var/lib/waagent/Incarnation
@@ -160,8 +154,6 @@ diagnostic | copy | /var/log/azure/run-command/handler.log
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
-diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
-diagnostic | copy | /var/lib/waagent/\*/config/HandlerStatus
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/\*.manifest.xml
@@ -1256,4 +1248,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-04-14 23:06:00.867930`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -20,6 +20,8 @@ agents | copy | /var/log/azure/\*/\*/\*
 agents | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
+agents | copy | /var/lib/waagent/\*/config/HandlerState
+agents | copy | /var/lib/waagent/\*/config/HandlerStatus
 agents | copy | /var/lib/waagent/GoalState.\*.xml
 agents | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 agents | copy | /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml
@@ -48,6 +50,8 @@ diagnostic | copy | /var/log/azure/\*/\*/\*
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerStatus
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml
@@ -86,6 +90,8 @@ agents | copy | /var/lib/waagent/\*.xml
 agents | copy | /var/lib/waagent/waagent_status.json
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
+agents | copy | /var/lib/waagent/\*/config/HandlerState
+agents | copy | /var/lib/waagent/\*/config/HandlerStatus
 agents | copy | /var/lib/waagent/\*.agentsManifest
 agents | copy | /var/lib/waagent/error.json
 agents | copy | /var/lib/waagent/Incarnation
@@ -154,6 +160,8 @@ diagnostic | copy | /var/log/azure/run-command/handler.log
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerStatus
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/\*.manifest.xml
@@ -1248,4 +1256,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-04-15 23:59:45.102914`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -20,6 +20,8 @@ agents | copy | /var/log/azure/\*/\*/\*
 agents | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
+agents | copy | /var/lib/waagent/\*/config/HandlerState
+agents | copy | /var/lib/waagent/\*/config/HandlerStatus
 agents | copy | /var/lib/waagent/GoalState.\*.xml
 agents | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 agents | copy | /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml
@@ -48,6 +50,8 @@ diagnostic | copy | /var/log/azure/\*/\*/\*
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerStatus
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.\*.manifest.xml
@@ -86,6 +90,8 @@ agents | copy | /var/lib/waagent/\*.xml
 agents | copy | /var/lib/waagent/waagent_status.json
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
+agents | copy | /var/lib/waagent/\*/config/HandlerState
+agents | copy | /var/lib/waagent/\*/config/HandlerStatus
 agents | copy | /var/lib/waagent/\*.agentsManifest
 agents | copy | /var/lib/waagent/error.json
 agents | copy | /var/lib/waagent/Incarnation
@@ -154,6 +160,8 @@ diagnostic | copy | /var/log/azure/run-command/handler.log
 diagnostic | copy | /var/lib/waagent/ExtensionsConfig.\*.xml
 diagnostic | copy | /var/lib/waagent/\*/status/\*.status
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
+diagnostic | copy | /var/lib/waagent/\*/config/HandlerStatus
 diagnostic | copy | /var/lib/waagent/GoalState.\*.xml
 diagnostic | copy | /var/lib/waagent/HostingEnvironmentConfig.xml
 diagnostic | copy | /var/lib/waagent/\*.manifest.xml
@@ -1248,4 +1256,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-03-11 10:28:14.406536`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-04-14 23:06:00.867930`*

--- a/pyServer/manifests/freebsd/agents
+++ b/pyServer/manifests/freebsd/agents
@@ -21,6 +21,8 @@ echo,### Gathering Extension Files ###
 copy,/var/lib/waagent/ExtensionsConfig.*.xml
 copy,/var/lib/waagent/*/status/*.status
 copy,/var/lib/waagent/*/config/*.settings
+copy,/var/lib/waagent/*/config/HandlerState
+copy,/var/lib/waagent/*/config/HandlerStatus
 copy,/var/lib/waagent/GoalState.*.xml
 copy,/var/lib/waagent/HostingEnvironmentConfig.xml
 copy,/var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.*.manifest.xml

--- a/pyServer/manifests/freebsd/diagnostic
+++ b/pyServer/manifests/freebsd/diagnostic
@@ -30,6 +30,8 @@ echo,### Gathering Extension Files ###
 copy,/var/lib/waagent/ExtensionsConfig.*.xml
 copy,/var/lib/waagent/*/status/*.status
 copy,/var/lib/waagent/*/config/*.settings
+copy,/var/lib/waagent/*/config/HandlerState
+copy,/var/lib/waagent/*/config/HandlerStatus
 copy,/var/lib/waagent/GoalState.*.xml
 copy,/var/lib/waagent/HostingEnvironmentConfig.xml
 copy,/var/lib/waagent/Microsoft.OSTCExtensions.CustomScriptForLinux.*.manifest.xml

--- a/pyServer/manifests/linux/agents
+++ b/pyServer/manifests/linux/agents
@@ -24,6 +24,8 @@ copy,/var/lib/waagent/*.xml
 copy,/var/lib/waagent/waagent_status.json
 copy,/var/lib/waagent/*/status/*.status
 copy,/var/lib/waagent/*/config/*.settings
+copy,/var/lib/waagent/*/config/HandlerState
+copy,/var/lib/waagent/*/config/HandlerStatus
 copy,/var/lib/waagent/*.agentsManifest
 copy,/var/lib/waagent/error.json
 copy,/var/lib/waagent/Incarnation

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -56,6 +56,8 @@ echo,### Gathering Extension Files ###
 copy,/var/lib/waagent/ExtensionsConfig.*.xml
 copy,/var/lib/waagent/*/status/*.status
 copy,/var/lib/waagent/*/config/*.settings
+copy,/var/lib/waagent/*/config/HandlerState
+copy,/var/lib/waagent/*/config/HandlerStatus
 copy,/var/lib/waagent/GoalState.*.xml
 copy,/var/lib/waagent/HostingEnvironmentConfig.xml
 copy,/var/lib/waagent/*.manifest.xml


### PR DESCRIPTION
Add HandlerState and HandlerStatus file to Inspect IaaS Disk Tool. This is needed by the Linux Guest Agent to debug the last extension state. 