### PR TITLE
Add EG IID files to be collected

### DIFF
--- a/pyServer/manifests/linux/eg
+++ b/pyServer/manifests/linux/eg
@@ -3,44 +3,98 @@ ll,/var/log
 ll,/var/lib/waagent
 ll,/etc/udev/rules.d
 
-echo,### Gathering Configuration Files ###
+echo,### Gathering Cloud-init Files ###
+copy,/var/log/cloud-init*
+copy,/var/cloud/cloud.cfg
+copy,/etc/cloud/cloud.cfg.d/*.cfg
+copy,/run/cloud-init/cloud.cfg
+copy,/run/cloud-init/ds-identify.log
+copy,/run/cloud-init/result.json
+copy,/run/cloud-init/status.json
+echo,
+
+echo,### Gathering Waagent Files ###
+copy,/var/log/waagent*
+copy,/etc/waagent.conf
 copy,/var/lib/waagent/provisioned
+copy,/var/lib/waagent/waagent_status.json
+echo,
+
+echo,### Gathering DHCP Files ###
+copy,/run/systemd/netif/leases/*
+copy,/var/lib/dhcp/*.leases
+copy,/var/lib/dhcp/*.lease
+copy,/var/lib/dhclient/*.leases
+copy,/var/lib/dhclient/*.lease
+copy,/var/lib/NetworkManager/*.leases
+copy,/var/lib/NetworkManager/*.lease
+copy,/run/cloud-init/dhclient.hooks/*.json
+copy,/var/lib/wicked/lease*
+echo,
+
+echo,### Gathering Networking Files ###
+copy,/etc/netplan/*.yaml
+copy,/etc/dhcp/*.conf
+copy,/etc/network/interfaces
+copy,/etc/network/interfaces.d/*.cfg
+copy,/etc/ufw/ufw.conf
+echo,
+
+echo,### Gathering NetworkManager Files ###
+copy,/var/lib/NetworkManager/*.conf
+copy,/var/lib/NetworkManager/conf.d/*.conf
+copy,/var/lib/NetworkManager/*.state
+copy,/usr/lib/NetworkManager/*.conf
+copy,/usr/lib/NetworkManager/conf.d/*.conf
+copy,/run/NetworkManager/*.conf
+copy,/run/NetworkManager/conf.d/*.conf
+copy,/etc/NetworkManager/*.conf
+copy,/etc/NetworkManager/conf.d/*.conf
+echo,
+
+echo,### Gathering Sysconfig Network Files ###
+copy,/etc/sysconfig/iptables
+copy,/etc/sysconfig/network
+copy,/etc/sysconfig/network/config
+copy,/etc/sysconfig/network/dhcp
+copy,/etc/sysconfig/network/ifcfg-*
+copy,/etc/sysconfig/network/routes
+copy,/etc/sysconfig/network-scripts/ifcfg-*
+copy,/etc/sysconfig/network-scripts/route-*
+copy,/etc/sysconfig/SuSEfirewall2
+echo,
+
+echo,### Gathering Wicked Network Files ###
+copy,/etc/wicked/*.xml
+echo,
+
+echo,### Gathering resolv.conf Files ###
+copy,/etc/resolv.conf
+copy,/run/systemd/resolve/*.conf
+copy,/run/resolvconf/*.conf
+echo,
+
+echo,### Gathering System Configuration Files ###
 copy,/etc/fstab
 copy,/boot/grub*/grub.c*
 copy,/boot/grub*/menu.lst
 copy,/etc/*-release
 copy,/etc/HOSTNAME
 copy,/etc/hostname
-copy,/etc/network/interfaces
-copy,/etc/network/interfaces.d/*.cfg
-copy,/etc/netplan/50-cloud-init.yaml
-copy,/etc/resolv.conf
-copy,/run/systemd/resolve/stub-resolv.conf
-copy,/run/resolvconf/resolv.conf
-copy,/etc/sysconfig/iptables
-copy,/etc/sysconfig/network
-copy,/etc/sysconfig/network/ifcfg-eth*
-copy,/etc/sysconfig/network/routes
-copy,/etc/sysconfig/network-scripts/ifcfg-eth*
-copy,/etc/sysconfig/network-scripts/route-eth*
-copy,/etc/sysconfig/SuSEfirewall2
-copy,/etc/ufw/ufw.conf
-copy,/etc/waagent.conf
-copy,/var/lib/dhcp/dhclient.eth0.leases
-copy,/var/lib/dhclient/dhclient-eth0.leases
-copy,/var/lib/wicked/lease-eth0-dhcp-ipv4.xml
 echo,
 
-echo,### Gathering Log Files ###
-copy,/var/log/waagent*
+echo,### Gathering Package Management Log Files ###
+copy,/var/log/dpkg*
+copy,/var/log/yum*
+copy,/var/log/dnf*
+echo,
+
+echo,### Gathering System Log Files ###
 copy,/var/log/syslog*
 copy,/var/log/rsyslog*
 copy,/var/log/messages*
 copy,/var/log/kern*
 copy,/var/log/dmesg*
-copy,/var/log/dpkg*
-copy,/var/log/yum*
-copy,/var/log/cloud-init*
 copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*


### PR DESCRIPTION
Add files that aid in diagnosing Linux provisioning failures.

New files added:

Cloud-init configs:
`/var/cloud/cloud.cfg`
`/etc/cloud/cloud.cfg.d/*.cfg`

Cloud-init runtime status:
`/run/cloud-init/cloud.cfg` (runtime-generated cfg of eligible DataSources)
`/run/cloud-init/ds-identify.log` (runtime results of identifying DataSources)
`/run/cloud-init/result.json` (DataSource search results)
`/run/cloud-init/status.json` (summary of results of different cloud-init stages)

Waagent runtime status:
`/var/lib/waagent/waagent_status.json`

Dhcp leases:
`/run/systemd/netif/leases/*`
`/var/lib/dhcp/*.leases`
`/var/lib/dhcp/*.lease`
`/var/lib/dhclient/*.leases`
`/var/lib/dhclient/*.lease`
`/var/lib/NetworkManager/*.leases`
`/var/lib/NetworkManager/*.lease`
`/run/cloud-init/dhclient.hooks/*.json`
`/var/lib/wicked/lease*`

Networking files configs (Ubuntu/Debian):
`/etc/netplan/*.yaml` (previously only gathered `50-cloud-init.yaml`)
`/etc/dhcp/*.conf` (newly-added, includes `dhclient.conf` and `dhclient-<device>.conf`)

NetworkManager configs (RHEL/CentOS):
`/var/lib/NetworkManager/*.conf`
`/var/lib/NetworkManager/conf.d/*.conf`
`/var/lib/NetworkManager/*.state` (describes the state of NetworkManager)
`/usr/lib/NetworkManager/*.conf`
`/usr/lib/NetworkManager/conf.d/*.conf`
`/run/NetworkManager/*.conf`
`/run/NetworkManager/conf.d/*.conf`
`/etc/NetworkManager/*.conf`
`/etc/NetworkManager/conf.d/*.conf`

Sysconfig Network configs (SUSE/SLES):
`/etc/sysconfig/network/config`
`/etc/sysconfig/network/dhcp`
`/etc/sysconfig/network/ifcfg-*` (previously only gathered `/etc/sysconfig/network/ifcfg-eth*`)
`/etc/sysconfig/network-scripts/ifcfg-*` (previously only gathered `/etc/sysconfig/network-scripts/ifcfg-eth*`)
`/etc/sysconfig/network-scripts/route-*` (previously only gathered `/etc/sysconfig/network-scripts/route-eth*`)

Wicked network manager configs (SUSE/SLES):
`/etc/wicked/*.xml` (Wicked configs)

resolvconf configs:
`/run/systemd/resolve/*.conf (previously only gathered `/run/systemd/resolve/stub-resolv.conf`)
`/run/resolvconf/*.conf` (previously only gathered `/run/resolvconf/resolv.conf`)

Package manager logs (RHEL/CentOS 8+ now uses DNF by default instead of YUM):
`copy,/var/log/dnf*`

