### PR TITLE
Add proc files to IID

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -95,6 +95,11 @@ File Path | Manifest
 /opt/msawb/var/lib/catalog/WorkloadSchedules/\*/\*.bin | workloadbackup 
 /opt/msawb/var/log/\*/\*/\* | workloadbackup 
 /opt/msawb/var/log/\*/\*/\*/\*/\* | workloadbackup 
+/proc/mounts | diagnostic, eg 
+/proc/net/ipv6_route | diagnostic, eg 
+/proc/net/route | diagnostic, eg 
+/proc/partitions | diagnostic, eg 
+/proc/version | diagnostic, eg 
 /run/NetworkManager/\*.conf | diagnostic, eg 
 /run/NetworkManager/conf.d/\*.conf | diagnostic, eg 
 /run/cloud-init/cloud.cfg | diagnostic, eg 
@@ -512,4 +517,4 @@ File Path | Manifest
 /k/azure-vnet.log | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-05-01 22:19:04.924851`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-05-21 01:47:02.740399`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -199,6 +199,11 @@ diagnostic | copy | /boot/grub\*/menu.lst
 diagnostic | copy | /etc/\*-release
 diagnostic | copy | /etc/HOSTNAME
 diagnostic | copy | /etc/hostname
+diagnostic | copy | /proc/version
+diagnostic | copy | /proc/net/route
+diagnostic | copy | /proc/net/ipv6_route
+diagnostic | copy | /proc/partitions
+diagnostic | copy | /proc/mounts
 diagnostic | diskinfo | 
 eg | list | /var/log
 eg | list | /var/lib/cloud
@@ -272,6 +277,11 @@ eg | copy | /boot/grub\*/menu.lst
 eg | copy | /etc/\*-release
 eg | copy | /etc/HOSTNAME
 eg | copy | /etc/hostname
+eg | copy | /proc/version
+eg | copy | /proc/net/route
+eg | copy | /proc/net/ipv6_route
+eg | copy | /proc/partitions
+eg | copy | /proc/mounts
 eg | diskinfo | 
 genspec | copy | /etc/hostname
 genspec | copy | /var/lib/waagent/provisioned
@@ -1317,4 +1327,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-05-01 22:19:04.924851`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-05-21 01:47:02.740399`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -121,5 +121,13 @@ copy,/etc/HOSTNAME
 copy,/etc/hostname
 echo,
 
+echo,### Gathering System Info ###
+copy,/proc/version
+copy,/proc/net/route
+copy,/proc/net/ipv6_route
+copy,/proc/partitions
+copy,/proc/mounts
+echo,
+
 echo,### Gathering Disk Info ###
 diskinfo,

--- a/pyServer/manifests/linux/eg
+++ b/pyServer/manifests/linux/eg
@@ -102,5 +102,13 @@ copy,/etc/HOSTNAME
 copy,/etc/hostname
 echo,
 
+echo,### Gathering System Info ###
+copy,/proc/version
+copy,/proc/net/route
+copy,/proc/net/ipv6_route
+copy,/proc/partitions
+copy,/proc/mounts
+echo,
+
 echo,### Gathering Disk Info ###
 diskinfo,


### PR DESCRIPTION
The following `/proc` files are being added to IID. These will be useful in diagnosing customer issues, especially when there are networking routing issues.

These files are small (around 5 lines) so it would not impact IID performance.

```
/proc/version                # kernel version
/proc/net/route            # ip routing table
/proc/net/ipv6_route    # ipv6 routing table
/proc/partitions            # partition info
/proc/mounts               # mount info
```