### PR TITLE
adding kubelet config file to AKS manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -510,6 +510,7 @@ File Path | Manifest
 /k/azure-vnet-ipam.log | aks 
 /k/azure-vnet.json | aks 
 /k/azure-vnet.log | aks 
+/k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-05-01 22:19:04.924851`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-02 17:33:03.074356`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -521,6 +521,7 @@ aks | copy | /Windows/System32/winevt/Logs/System.evtx
 aks | copy | /Windows/System32/winevt/Logs/Application.evtx
 aks | copy | /k/\*.log
 aks | copy | /k/\*.err
+aks | copy | /k/config
 aks | copy | /k/azure-vnet.log
 aks | copy | /k/azure-vnet-ipam.log
 aks | copy | /k/azure-vnet.json
@@ -1317,4 +1318,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-05-01 22:19:04.924851`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-02 17:33:03.074356`*

--- a/pyServer/manifests/windows/aks
+++ b/pyServer/manifests/windows/aks
@@ -5,6 +5,7 @@ copy,/Windows/System32/winevt/Logs/Application.evtx
 echo,## Kubelet and Kube proxy Logs ##
 copy,/k/*.log
 copy,/k/*.err
+copy,/k/config
 
 echo,## CNI logs ##
 copy,/k/azure-vnet.log


### PR DESCRIPTION
adding kubelet config file to AKS manifest

CRI 190534195 - where the kubelet config file is not parsing correctly from YAML to JSON - causing Windows node pool to fail creating