### PR TITLE
adding AKS cluster-provision.log file

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -161,7 +161,7 @@ File Path | Manifest
 /var/log/azure/\* | site-recovery, workloadbackup 
 /var/log/azure/\*/\* | agents, diagnostic 
 /var/log/azure/\*/\*/\* | agents, diagnostic 
-/var/log/azure/cluster-provision.log | aks 
+/var/log/azure/cluster-provision.log | aks, diagnostic 
 /var/log/azure/custom-script/handler.log | agents, diagnostic 
 /var/log/azure/docker-status.log | aks 
 /var/log/azure/kern.log | aks 
@@ -513,4 +513,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-02 17:33:03.074356`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-16 17:57:40.646912`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -193,6 +193,7 @@ diagnostic | copy | /var/log/azure/\*/\*
 diagnostic | copy | /var/log/azure/\*/\*/\*
 diagnostic | copy | /var/log/azure/custom-script/handler.log
 diagnostic | copy | /var/log/azure/run-command/handler.log
+diagnostic | copy | /var/log/azure/cluster-provision.log
 diagnostic | copy | /etc/fstab
 diagnostic | copy | /boot/grub\*/grub.c\*
 diagnostic | copy | /boot/grub\*/menu.lst
@@ -1322,4 +1323,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-02 17:33:03.074356`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-16 17:57:40.646912`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -110,6 +110,7 @@ copy,/var/log/azure/*/*
 copy,/var/log/azure/*/*/*
 copy,/var/log/azure/custom-script/handler.log
 copy,/var/log/azure/run-command/handler.log
+copy,/var/log/azure/cluster-provision.log
 echo,
 
 echo,### Gathering System Configuration Files ###


### PR DESCRIPTION
 - to get it automatically collected on AKS cases - before customer/AKS deletes the VM.

expected size of the file = 50KB

Background = CRI 191994148 where an AKS with GPU node pool failing to start - and it was deleted as costing too much
