### PR TITLE
adding NVidia installer logs to the Linux AKS manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -181,6 +181,7 @@ File Path | Manifest
 /var/log/kern.log | servicefabric 
 /var/log/kern\* | diagnostic, eg, normal 
 /var/log/messages\* | diagnostic, eg, monitor-mgmt, normal 
+/var/log/nvidia\*.log | aks 
 /var/log/pods/kube-system\*/\*/\*.log | aks 
 /var/log/rsyslog\* | diagnostic, eg, lad, normal 
 /var/log/s2\*.log | site-recovery 
@@ -513,4 +514,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-16 17:57:40.646912`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-17 17:43:00.107929`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -110,6 +110,7 @@ aks | copy | /var/log/azure-vnet\*
 aks | copy | /var/run/azure-vnet\*
 aks | copy | /var/log/pods/kube-system\*/\*/\*.log
 aks | copy | /var/lib/docker/containers/\*/\*-json.log
+aks | copy | /var/log/nvidia\*.log
 aks | list | /var/log/pods/\*/\*
 diagnostic | list | /var/log
 diagnostic | list | /var/lib/cloud
@@ -1323,4 +1324,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-16 17:57:40.646912`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-06-17 17:43:00.107929`*

--- a/pyServer/manifests/linux/aks
+++ b/pyServer/manifests/linux/aks
@@ -22,5 +22,8 @@ echo,### kube-system pod logs ###
 copy,/var/log/pods/kube-system*/*/*.log
 copy,/var/lib/docker/containers/*/*-json.log
 
+echo,### NVidia installer logs for GPU nodes ###
+copy,/var/log/nvidia*.log
+
 echo,### list of pods and associated symlink to nav the container logs ###
 ll,/var/log/pods/*/*


### PR DESCRIPTION
Backlog work item 6604: Collect nvidia-installer-XYZ.log for AKS cases 

for AKS using GPU nodes, they sometimes fail installing the NVidia drivers. We need at least the /var/log/nvidia*.log installer logs to troubleshoot