### PR TITLE
Add WinGA install log VmAgentInstaller.xml

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -353,6 +353,7 @@ File Path | Manifest
 /Windows/Minidump/\*.dmp | windowsupdate 
 /Windows/Panther/FastCleanup/setupact.log | diagnostic, eg, normal, windowsupdate 
 /Windows/Panther/UnattendGC/setupact.log | diagnostic, eg, normal, windowsupdate 
+/Windows/Panther/VmAgentInstaller.xml | agents, diagnostic, normal, windowsupdate 
 /Windows/Panther/WaSetup.log | diagnostic, eg, normal, windowsupdate 
 /Windows/Panther/WaSetup.xml | agents, diagnostic, eg, genspec, normal, site-recovery, windowsupdate 
 /Windows/Panther/miglog.xml | windowsupdate 
@@ -532,4 +533,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-07-19 16:15:50.721070`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-08-21 11:30:21.751351`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -426,6 +426,7 @@ agents | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-DSC%4Operational
 agents | copy | /AzureData/CustomData.bin
 agents | copy | /Windows/Setup/State/state.ini
 agents | copy | /Windows/Panther/WaSetup.xml
+agents | copy | /Windows/Panther/VmAgentInstaller.xml
 agents | list | /WindowsAzure
 agents | list | /Packages/Plugins
 agents | copy | /WindowsAzure/Logs/Telemetry.log
@@ -592,6 +593,7 @@ diagnostic | copy | /AzureData/CustomData.bin
 diagnostic | copy | /Windows/Setup/State/State.ini
 diagnostic | copy | /Windows/Panther/WaSetup.xml
 diagnostic | copy | /Windows/Panther/WaSetup.log
+diagnostic | copy | /Windows/Panther/VmAgentInstaller.xml
 diagnostic | copy | /Windows/Panther/unattend.xml
 diagnostic | copy | /unattend.xml
 diagnostic | copy | /Windows/Panther/setupact.log
@@ -866,6 +868,7 @@ normal | copy | /AzureData/CustomData.bin
 normal | copy | /Windows/Setup/State/state.ini
 normal | copy | /Windows/Panther/WaSetup.xml
 normal | copy | /Windows/Panther/WaSetup.log
+normal | copy | /Windows/Panther/VmAgentInstaller.xml
 normal | copy | /Windows/Panther/unattend.xml
 normal | copy | /unattend.xml
 normal | copy | /Windows/Panther/setupact.log
@@ -1141,6 +1144,7 @@ windowsupdate | copy | /AzureData/CustomData.bin
 windowsupdate | copy | /Windows/Setup/State/State.ini
 windowsupdate | copy | /Windows/Panther/WaSetup.xml
 windowsupdate | copy | /Windows/Panther/WaSetup.log
+windowsupdate | copy | /Windows/Panther/VmAgentInstaller.xml
 windowsupdate | copy | /Windows/Panther/unattend.xml
 windowsupdate | copy | /unattend.xml
 windowsupdate | copy | /Windows/Panther/setupact.log
@@ -1341,4 +1345,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-07-19 16:15:50.721070`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-08-21 11:30:21.751351`*

--- a/pyServer/manifests/windows/agents
+++ b/pyServer/manifests/windows/agents
@@ -30,6 +30,7 @@ echo,### Provisioning ###
 copy,/AzureData/CustomData.bin
 copy,/Windows/Setup/State/state.ini
 copy,/Windows/Panther/WaSetup.xml
+copy,/Windows/Panther/VmAgentInstaller.xml
 
 echo,### Guest Agent ###
 ll,/WindowsAzure
@@ -125,4 +126,3 @@ copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.Edp.NetworkWatche
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.Edp.NetworkWatcherAgentWindows/*/*.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/*/*.txt
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/*/*.log
-

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -63,6 +63,7 @@ copy,/AzureData/CustomData.bin
 copy,/Windows/Setup/State/State.ini
 copy,/Windows/Panther/WaSetup.xml
 copy,/Windows/Panther/WaSetup.log
+copy,/Windows/Panther/VmAgentInstaller.xml
 copy,/Windows/Panther/unattend.xml
 copy,/unattend.xml
 copy,/Windows/Panther/setupact.log

--- a/pyServer/manifests/windows/normal
+++ b/pyServer/manifests/windows/normal
@@ -13,6 +13,7 @@ copy,/AzureData/CustomData.bin
 copy,/Windows/Setup/State/state.ini
 copy,/Windows/Panther/WaSetup.xml
 copy,/Windows/Panther/WaSetup.log
+copy,/Windows/Panther/VmAgentInstaller.xml
 copy,/Windows/Panther/unattend.xml
 copy,/unattend.xml
 copy,/Windows/Panther/setupact.log

--- a/pyServer/manifests/windows/windowsupdate
+++ b/pyServer/manifests/windows/windowsupdate
@@ -65,6 +65,7 @@ copy,/AzureData/CustomData.bin
 copy,/Windows/Setup/State/State.ini
 copy,/Windows/Panther/WaSetup.xml
 copy,/Windows/Panther/WaSetup.log
+copy,/Windows/Panther/VmAgentInstaller.xml
 copy,/Windows/Panther/unattend.xml
 copy,/unattend.xml
 copy,/Windows/Panther/setupact.log


### PR DESCRIPTION
WinGA install logs to C:\Windows\Panther\VmAgentInstaller.xml to it is important that we collect it for WinGA install troubleshooting. 

Added it to diagnostic, agents, and normal manifests.