### PR TITLE
Fix path for error.json

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -144,8 +144,9 @@ File Path | Manifest
 /var/lib/waagent/\*/config/HandlerState | agents, diagnostic 
 /var/lib/waagent/\*/config/HandlerStatus | agents, diagnostic 
 /var/lib/waagent/\*/config/\*.settings | agents, diagnostic 
+/var/lib/waagent/\*/error.json | diagnostic 
 /var/lib/waagent/\*/status/\*.status | agents, diagnostic 
-/var/lib/waagent/error.json | agents, diagnostic, eg 
+/var/lib/waagent/error.json | agents, eg 
 /var/lib/waagent/history/\*.zip | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, eg, genspec 
 /var/lib/waagent/waagent_status.json | agents, diagnostic, eg 
@@ -539,4 +540,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-09-15 22:46:14.816650`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-10-16 13:37:59.098382`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -130,7 +130,7 @@ diagnostic | copy | /var/log/waagent\*
 diagnostic | copy | /etc/waagent.conf
 diagnostic | copy | /var/lib/waagent/provisioned
 diagnostic | copy | /var/lib/waagent/waagent_status.json
-diagnostic | copy | /var/lib/waagent/error.json
+diagnostic | copy | /var/lib/waagent/\*/error.json
 diagnostic | copy | /var/lib/waagent/\*.manifest.xml
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
 diagnostic | copy | /var/lib/waagent/\*/config/HandlerState
@@ -1351,4 +1351,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-09-15 22:46:14.816650`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-10-16 13:37:59.098382`*

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -20,7 +20,7 @@ copy,/var/log/waagent*
 copy,/etc/waagent.conf
 copy,/var/lib/waagent/provisioned
 copy,/var/lib/waagent/waagent_status.json
-copy,/var/lib/waagent/error.json
+copy,/var/lib/waagent/*/error.json
 copy,/var/lib/waagent/*.manifest.xml
 copy,/var/lib/waagent/*/config/*.settings
 copy,/var/lib/waagent/*/config/HandlerState


### PR DESCRIPTION
There are multiple instances of error.json, each in a different directory. Added a wildcard to handle that. 

Those are very small files and usually do not exist; when they do exist there should be just a few of them (2 or 3).