### PR TITLE
azure-npm logs

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -156,6 +156,7 @@ File Path | Manifest
 /var/log/ambari-server/ambari-audit.log | hdinsight 
 /var/log/ambari-server/ambari-server.log | hdinsight 
 /var/log/auth\* | agents, diagnostic, eg, normal 
+/var/log/azure-npm.log | aks 
 /var/log/azure-vnet\* | aks 
 /var/log/azure/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode/\*.\*/CommandExec<br>ution.log | servicefabric 
 /var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/\*/\*.log | monitor-mgmt 
@@ -540,4 +541,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-10-16 13:37:59.098382`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-10-27 13:29:09.745352`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -110,6 +110,7 @@ aks | copy | /var/log/azure-vnet\*
 aks | copy | /var/run/azure-vnet\*
 aks | copy | /run/azure-vnet\*
 aks | copy | /etc/cni/net.d/10-azure.conflist
+aks | copy | /var/log/azure-npm.log
 aks | copy | /var/log/pods/kube-system\*/\*/\*.log
 aks | copy | /var/lib/docker/containers/\*/\*-json.log
 aks | copy | /var/log/nvidia\*.log
@@ -1351,4 +1352,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-10-16 13:37:59.098382`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-10-27 13:29:09.745352`*

--- a/pyServer/manifests/linux/aks
+++ b/pyServer/manifests/linux/aks
@@ -20,6 +20,9 @@ copy,/var/run/azure-vnet*
 copy,/run/azure-vnet*
 copy,/etc/cni/net.d/10-azure.conflist
 
+echo,### NPM logs ###
+copy,/var/log/azure-npm.log
+
 echo,### kube-system pod logs ###
 copy,/var/log/pods/kube-system*/*/*.log
 copy,/var/lib/docker/containers/*/*-json.log


### PR DESCRIPTION
This PR adds the Azure NPM log file, `/var/log/azure-npm.log`, which is supported on Linux only.