### PR TITLE
adding containerd status

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -173,6 +173,7 @@ File Path | Manifest
 /var/log/azure/\*/\* | agents, diagnostic 
 /var/log/azure/\*/\*/\* | agents, diagnostic 
 /var/log/azure/cluster-provision.log | aks, diagnostic 
+/var/log/azure/containerd-status.log | aks 
 /var/log/azure/custom-script/handler.log | agents, diagnostic 
 /var/log/azure/docker-status.log | aks 
 /var/log/azure/kern.log | aks 
@@ -552,4 +553,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-12-17 16:49:06.090451`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-01-11 12:59:20.499599`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -106,6 +106,7 @@ aks | copy | /var/log/azure/docker-status.log
 aks | copy | /var/log/azure/kubelet-status.log
 aks | copy | /var/log/azure/kern.log
 aks | copy | /var/log/journal/\*/\*
+aks | copy | /var/log/azure/containerd-status.log
 aks | copy | /var/log/azure-vnet\*
 aks | copy | /var/run/azure-vnet\*
 aks | copy | /run/azure-vnet\*
@@ -1368,4 +1369,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2020-12-17 16:49:06.090451`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-01-11 12:59:20.499599`*

--- a/pyServer/manifests/linux/aks
+++ b/pyServer/manifests/linux/aks
@@ -14,6 +14,9 @@ copy,/var/log/azure/kubelet-status.log
 copy,/var/log/azure/kern.log
 copy,/var/log/journal/*/*,noscan
 
+echo,### containerd ###
+copy,/var/log/azure/containerd-status.log
+
 echo,### CNI logs ###
 copy,/var/log/azure-vnet* 
 copy,/var/run/azure-vnet*


### PR DESCRIPTION
Adding the status file specific to containerd which is used on clusters running k8s v 19+ by default.
File will be similar to impact/size as /var/log/azure/docker-status.log - which is a small file