### PR TITLE
AKS: Collect Calico Windows logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ To copy the logs over for examination on the host:
 	4.	Apply your changes in the branch
 
 		-If you are updating/creating new manifest then: Make sure to run "parse_manifest.py"
+		 $ cd ./tools/
 		 $ python ./parse_manifest.py
+		 $ cd -
 
 	5.	Push changes to your remote branch by following below sequesnce of commands
 		$ git add <file_changed>

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -554,4 +554,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-02-03 08:55:03.499169`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-02-04 08:46:39.145891`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -239,6 +239,7 @@ File Path | Manifest
 /AzureData/CustomDataSetupScript.log | aks 
 /AzureData/CustomDataSetupScript.ps1 | aks 
 /Boot/BCD | windowsupdate 
+/CalicoWindows/logs/\*.log | aks 
 /Packages/Plugins/ESET.FileSecurity/\*/agent_version.txt | agents, diagnostic, normal, windowsupdate 
 /Packages/Plugins/ESET.FileSecurity/\*/extension_version.txt | agents, diagnostic, normal, windowsupdate 
 /Packages/Plugins/Microsoft.Azure.Diagnostics.IaaSDiagnostics/\*/AnalyzerConfigTempla<br>te.xml | agents, diagnostic, normal, windowsupdate 
@@ -553,4 +554,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-01-11 12:59:20.499599`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-02-03 08:55:03.499169`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -557,6 +557,7 @@ aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Servic
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Admin.evtx
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Operational.evtx
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Service-Operational.evtx
+aks | copy | /CalicoWindows/logs/\*.log
 aks | copy | /AzureData/CustomDataSetupScript.log
 aks | copy | /AzureData/CustomDataSetupScript.ps1
 asc-vmhealth | copy | /WindowsAzure/Logs/TransparentInstaller.log
@@ -1369,4 +1370,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-01-11 12:59:20.499599`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-02-03 08:55:03.499169`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -1370,4 +1370,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-02-03 08:55:03.499169`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-02-04 08:46:39.145891`*

--- a/pyServer/manifests/windows/aks
+++ b/pyServer/manifests/windows/aks
@@ -19,8 +19,8 @@ copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Admin.evtx
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Operational.evtx
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Service-Operational.evtx
 
-
-
+echo,### Calico Windows logs
+copy,/CalicoWindows/logs/*.log
 
 echo,## Cluster provision logs ##
 copy,/AzureData/CustomDataSetupScript.log

--- a/pyServer/manifests/windows/aks
+++ b/pyServer/manifests/windows/aks
@@ -20,7 +20,7 @@ copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Operational
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Service-Operational.evtx
 
 echo,### Calico Windows logs
-copy,/CalicoWindows/logs/*.log
+copy,/CalicoWindows/logs/*.log,noscan
 
 echo,## Cluster provision logs ##
 copy,/AzureData/CustomDataSetupScript.log


### PR DESCRIPTION
We need to collect these logs in AKS Windows nodes for troubleshooting.
C:\CalicoWindows only exists when provisioning AKS Windows nodes for using calico as network policy.

For #175