### PR TITLE
add AKS Windows containerd log into disk inspector

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -342,6 +342,7 @@ File Path | Manifest
 /ProgramData/Microsoft/System Center/Orchestrator/7.2/SMA/\*.\* | monitor-mgmt 
 /ProgramData/USOShared/Logs/\*.etl | windowsupdate 
 /ProgramData/UsoPrivate/UpdateStore/\*.xml | windowsupdate 
+/ProgramData/containerd/root/panic.log | aks 
 /Users/\*/AppData/Local/Packages/WinStore_cw5n1h2txyewy/AC/Temp/winstore.log | windowsupdate 
 /Users/\*/AppData/Local/Temp/winstore.log | windowsupdate 
 /Users/\*/AppData/Local/microsoft/windows/windowsupdate.log | windowsupdate 
@@ -554,4 +555,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-03-04 14:17:38.932535`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-19 13:45:24.098091`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -555,4 +555,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-19 13:45:24.098091`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-20 15:14:56.985533`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -1371,4 +1371,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-19 13:45:24.098091`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-20 15:14:56.985533`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -558,6 +558,7 @@ aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Adm
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Operational.evtx
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Service-Operational.evtx
 aks | copy | /CalicoWindows/logs/\*.log
+aks | copy | /ProgramData/containerd/root/panic.log
 aks | copy | /AzureData/CustomDataSetupScript.log
 aks | copy | /AzureData/CustomDataSetupScript.ps1
 asc-vmhealth | copy | /WindowsAzure/Logs/TransparentInstaller.log
@@ -1370,4 +1371,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-03-04 14:17:38.932535`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-19 13:45:24.098091`*

--- a/pyServer/manifests/windows/aks
+++ b/pyServer/manifests/windows/aks
@@ -23,7 +23,7 @@ echo,### Calico Windows logs ###
 copy,/CalicoWindows/logs/*.log,noscan
 
 echo,### Contained panic log ###
-copy,/ProgramData/containerd/root/panic.log
+copy,/ProgramData/containerd/root/panic.log,noscan
 
 echo,### Cluster provision logs ###
 copy,/AzureData/CustomDataSetupScript.log

--- a/pyServer/manifests/windows/aks
+++ b/pyServer/manifests/windows/aks
@@ -2,32 +2,32 @@ echo,### Event Logs ###
 copy,/Windows/System32/winevt/Logs/System.evtx 
 copy,/Windows/System32/winevt/Logs/Application.evtx 
 
-echo,## Kubelet and Kube proxy Logs ##
+echo,### Logs of services including but not limited to Kubelet, Kube proxy and containerd ###
 copy,/k/*.log
 copy,/k/*.err
 copy,/k/config
 
-echo,## CNI logs ##
+echo,### CNI logs ###
 copy,/k/azure-vnet.log
 copy,/k/azure-vnet-ipam.log
 copy,/k/azure-vnet.json
 copy,/k/azure-vnet-ipam.json
 
-echo,## Hyper-V logs ##
+echo,### Hyper-V logs ###
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Service-Admin.evtx
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Admin.evtx
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Hyper-V-Compute-Operational.evtx
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Service-Operational.evtx
 
-echo,### Calico Windows logs
+echo,### Calico Windows logs ###
 copy,/CalicoWindows/logs/*.log,noscan
 
-echo,## Cluster provision logs ##
+echo,### Contained panic log ###
+copy,/ProgramData/containerd/root/panic.log
+
+echo,### Cluster provision logs ###
 copy,/AzureData/CustomDataSetupScript.log
 copy,/AzureData/CustomDataSetupScript.ps1
-
-
-
 
 
 


### PR DESCRIPTION
- AKS Windows containerd is stored in under c:\k which is covered by the previous collection.
- Add containerd panic log.