### PR TITLE
Adding ifcfg-eth0 to Min-Diagnostic Manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -75,6 +75,7 @@ File Path | Manifest
 /etc/sysconfig/iptables | diagnostic, eg 
 /etc/sysconfig/network | diagnostic, eg 
 /etc/sysconfig/network-scripts/ifcfg-\* | diagnostic, eg 
+/etc/sysconfig/network-scripts/ifcfg-eth0 | normal 
 /etc/sysconfig/network-scripts/route-\* | diagnostic, eg 
 /etc/sysconfig/network/config | diagnostic, eg 
 /etc/sysconfig/network/dhcp | diagnostic, eg 
@@ -555,4 +556,4 @@ File Path | Manifest
 /k/config | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-20 15:14:56.985533`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-29 12:32:20.276331`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -335,6 +335,7 @@ normal | list | /var/log
 normal | list | /etc/udev/rules.d
 normal | copy | /etc/fstab
 normal | copy | /etc/ssh/sshd_config
+normal | copy | /etc/sysconfig/network-scripts/ifcfg-eth0
 normal | copy | /var/log/waagent\*
 normal | copy | /var/log/syslog\*
 normal | copy | /var/log/rsyslog\*
@@ -1371,4 +1372,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-20 15:14:56.985533`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-29 12:32:20.276331`*

--- a/pyServer/manifests/linux/normal
+++ b/pyServer/manifests/linux/normal
@@ -5,6 +5,7 @@ ll,/etc/udev/rules.d
 echo,### Gathering Configuration Files ###
 copy,/etc/fstab
 copy,/etc/ssh/sshd_config
+copy,/etc/sysconfig/network-scripts/ifcfg-eth0
 echo,
 
 echo,### Gathering Log Files ###


### PR DESCRIPTION
I'm working on creating an Insight for ASC which uses IID. I need ifcfg-eth0 file to be included in the Min-Diagnostic Mode so that we can use this file to create an insight.