### PR TITLE
collect kubeclusterconfig.json in AKS Windows nodes

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -554,6 +554,7 @@ File Path | Manifest
 /k/azure-vnet.json | aks 
 /k/azure-vnet.log | aks 
 /k/config | aks 
+/k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-29 12:32:20.276331`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-05-06 09:59:21.183339`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -550,6 +550,7 @@ aks | copy | /Windows/System32/winevt/Logs/Application.evtx
 aks | copy | /k/\*.log
 aks | copy | /k/\*.err
 aks | copy | /k/config
+aks | copy | /k/kubeclusterconfig.json
 aks | copy | /k/azure-vnet.log
 aks | copy | /k/azure-vnet-ipam.log
 aks | copy | /k/azure-vnet.json
@@ -1372,4 +1373,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-04-29 12:32:20.276331`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-05-06 09:59:21.183339`*

--- a/pyServer/manifests/windows/aks
+++ b/pyServer/manifests/windows/aks
@@ -6,6 +6,7 @@ echo,### Logs of services including but not limited to Kubelet, Kube proxy and c
 copy,/k/*.log
 copy,/k/*.err
 copy,/k/config
+copy,/k/kubeclusterconfig.json
 
 echo,### CNI logs ###
 copy,/k/azure-vnet.log


### PR DESCRIPTION
kubeclusterconfig.json does not contain any credentials but it contains some parameters for trouble shooting, for example, WinDSR=true, WinOverlay=false is included in FeatureGates when enabling WinDSR.

Reference https://github.com/Azure/AgentBaker/pull/800