### PR TITLE
Docker Locale set to C.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,3 +65,8 @@ EXPOSE 8080
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+
+
+# Set the locale
+ENV LANG=C.UTF-8
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,5 @@ ENTRYPOINT ["/entrypoint.sh"]
 # Set the locale
 ENV LANG=C.UTF-8
 ENV LANGUAGE=C.UTF-8
+ENV LC_ALL=C.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,5 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 # Set the locale
 ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
 


### PR DESCRIPTION
Fixes some UnicodeEncodingErrors caused by ASCII unable to decode unicode characters in IID