### PR TITLE
Include newfile linux waagent_status.{0}.json for Linux Guest Agent

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -156,8 +156,8 @@ File Path | Manifest
 /var/lib/waagent/error.json | agents, eg 
 /var/lib/waagent/history/\*.zip | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, eg, genspec 
-/var/lib/waagent/waagent_status.json | agents, diagnostic, eg 
 /var/lib/waagent/waagent_status.\*.json | agents, diagnostic, eg 
+/var/lib/waagent/waagent_status.json | agents, diagnostic, eg 
 /var/lib/wicked/lease\* | diagnostic, eg 
 /var/log/AzureRcmCli.log | site-recovery 
 /var/log/ambari-agent/ambari-agent.log | hdinsight 
@@ -559,4 +559,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-07 17:19:11.452946`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-19 12:21:47.636334`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -157,6 +157,7 @@ File Path | Manifest
 /var/lib/waagent/history/\*.zip | agents, diagnostic 
 /var/lib/waagent/provisioned | diagnostic, eg, genspec 
 /var/lib/waagent/waagent_status.json | agents, diagnostic, eg 
+/var/lib/waagent/waagent_status.\*.json | agents, diagnostic, eg 
 /var/lib/wicked/lease\* | diagnostic, eg 
 /var/log/AzureRcmCli.log | site-recovery 
 /var/log/ambari-agent/ambari-agent.log | hdinsight 

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -559,4 +559,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-19 12:21:47.636334`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-20 13:27:13.805782`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -88,6 +88,7 @@ agents | copy | /var/log/azure/\*/\*/\*
 agents | copy | /var/log/azure/custom-script/handler.log
 agents | copy | /var/lib/waagent/\*.xml
 agents | copy | /var/lib/waagent/waagent_status.json
+agents | copy | /var/lib/waagent/waagent_status.\*.json
 agents | copy | /var/lib/waagent/\*/status/\*.status
 agents | copy | /var/lib/waagent/\*/config/\*.settings
 agents | copy | /var/lib/waagent/\*/config/HandlerState
@@ -132,6 +133,7 @@ diagnostic | copy | /var/log/waagent\*
 diagnostic | copy | /etc/waagent.conf
 diagnostic | copy | /var/lib/waagent/provisioned
 diagnostic | copy | /var/lib/waagent/waagent_status.json
+diagnostic | copy | /var/lib/waagent/waagent_status.\*.json
 diagnostic | copy | /var/lib/waagent/\*/error.json
 diagnostic | copy | /var/lib/waagent/\*.manifest.xml
 diagnostic | copy | /var/lib/waagent/\*/config/\*.settings
@@ -222,6 +224,7 @@ eg | copy | /var/log/waagent\*
 eg | copy | /etc/waagent.conf
 eg | copy | /var/lib/waagent/provisioned
 eg | copy | /var/lib/waagent/waagent_status.json
+eg | copy | /var/lib/waagent/waagent_status.\*.json
 eg | copy | /var/lib/waagent/error.json
 eg | copy | /run/systemd/netif/leases/\*
 eg | copy | /var/lib/NetworkManager/\*.lease

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -1377,4 +1377,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-07 17:19:11.452946`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-19 12:21:47.636334`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -1377,4 +1377,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-19 12:21:47.636334`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2021-07-20 13:27:13.805782`*

--- a/pyServer/manifests/linux/agents
+++ b/pyServer/manifests/linux/agents
@@ -22,6 +22,7 @@ echo,
 echo,### Gathering Extension Files ###
 copy,/var/lib/waagent/*.xml
 copy,/var/lib/waagent/waagent_status.json
+copy,/var/lib/waagent/waagent_status.*.json
 copy,/var/lib/waagent/*/status/*.status
 copy,/var/lib/waagent/*/config/*.settings
 copy,/var/lib/waagent/*/config/HandlerState

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -20,6 +20,7 @@ copy,/var/log/waagent*
 copy,/etc/waagent.conf
 copy,/var/lib/waagent/provisioned
 copy,/var/lib/waagent/waagent_status.json
+copy,/var/lib/waagent/waagent_status.*.json
 copy,/var/lib/waagent/*/error.json
 copy,/var/lib/waagent/*.manifest.xml
 copy,/var/lib/waagent/*/config/*.settings

--- a/pyServer/manifests/linux/eg
+++ b/pyServer/manifests/linux/eg
@@ -20,6 +20,7 @@ copy,/var/log/waagent*
 copy,/etc/waagent.conf
 copy,/var/lib/waagent/provisioned
 copy,/var/lib/waagent/waagent_status.json
+copy,/var/lib/waagent/waagent_status.*.json
 copy,/var/lib/waagent/error.json
 echo,
 


### PR DESCRIPTION
New file of the format waagent_status.{0}.json needs to be onboarded to inspect disk.

-  There will be one file at an instance. And the wild card character denoted the incarnation number. When incarnation number changes the file name changes.

- Expected File Size ~5kB 