### PR TITLE
Adds VmApps files

### DIFF
--- a/pyServer/manifests/linux/agents
+++ b/pyServer/manifests/linux/agents
@@ -26,6 +26,8 @@ copy,/var/lib/waagent/*/status/*.status
 copy,/var/lib/waagent/*/config/*.settings
 copy,/var/lib/waagent/*/config/HandlerState
 copy,/var/lib/waagent/*/config/HandlerStatus
+copy,/var/lib/waagent/*/config/VMApp.lockfile
+copy,/var/lib/waagent/*/config/applicationRegistry.active
 copy,/var/lib/waagent/*.agentsManifest
 copy,/var/lib/waagent/error.json
 copy,/var/lib/waagent/Incarnation

--- a/pyServer/manifests/windows/normal
+++ b/pyServer/manifests/windows/normal
@@ -134,4 +134,7 @@ copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.Edp.NetworkWatche
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.Edp.NetworkWatcherAgentWindows/*/*.log
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/*/*.txt
 copy,/WindowsAzure/Logs/Plugins/Microsoft.Azure.NetworkWatcher.NetworkWatcherAgentWindows/*/*.log
-
+copy,/WindowsAzure/Logs/Plugins/Microsoft.CPlat.Core.VMApplicationManagerWindows/*/*.log
+copy,/Packages/Plugins/Microsoft.CPlat.Core.VMApplicationManagerWindows/*/RuntimeSettings/applicationRegistry.active
+copy,/Packages/Plugins/Microsoft.CPlat.Core.VMApplicationManagerWindows/*/RuntimeSettings/applicationRegistry.backup
+copy,/Packages/Plugins/Microsoft.CPlat.Core.VMApplicationManagerWindows/*/RuntimeSettings/VMApp.lockfile


### PR DESCRIPTION
Adds files necessary for VmApps debugging. This applies to Windows and Linux.
VmApp.lockfile - small single-byte file used for synchronization
applicationRegistry.active - contains the list of applications we've installed and their status. Should be no larger than 5 kb.
log files for VmApplication extension - should be similar in length to other extensions, particularly RunCommand