### PR TITLE
axelg adding AKSNode log

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -196,6 +196,7 @@ File Path | Manifest
 /var/log/auth\* | agents, diagnostic, eg, normal, vmdiagnostic 
 /var/log/azure-npm.log | aks 
 /var/log/azure-vnet\* | aks 
+/var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.log | aks 
 /var/log/azure/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode/\*.\*/CommandExec<br>ution.log | servicefabric 
 /var/log/azure/Microsoft.EnterpriseCloud.Monitoring.OmsAgentForLinux/\*/\*.log | monitor-mgmt 
 /var/log/azure/Microsoft.OSTCExtensions.DSCForLinux/extension.log | monitor-mgmt 
@@ -611,4 +612,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-03-22 18:43:36.426685`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-03-28 13:22:01.702364`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -149,6 +149,7 @@ aks | copy | /var/log/pods/kube-system\*/\*/\*.log
 aks | copy | /var/lib/docker/containers/\*/\*-json.log
 aks | copy | /var/log/nvidia\*.log
 aks | list | /var/log/pods/\*/\*
+aks | copy | /var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.log
 diagnostic | list | /boot
 diagnostic | list | /var/log
 diagnostic | list | /var/lib/cloud
@@ -1770,4 +1771,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-03-22 18:43:36.426685`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-03-28 13:22:01.702364`*

--- a/pyServer/manifests/linux/aks
+++ b/pyServer/manifests/linux/aks
@@ -35,3 +35,7 @@ copy,/var/log/nvidia*.log,noscan
 
 echo,### list of pods and associated symlink to nav the container logs ###
 ll,/var/log/pods/*/*
+
+echo,### AKSNode extension logs ###
+copy,/var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.log
+


### PR DESCRIPTION
[Backlog work item 26393](https://supportability.visualstudio.com/AzureContainers/_workitems/edit/26393): axleg to add the AKSNode extension log into the InspectIaaSDisk manifest for AKS


Adding the AKSNode extension log to Azure Disk Inspect