### PR TITLE
chore: add CNS logs to diskinspect

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -194,6 +194,7 @@ File Path | Manifest
 /var/log/ambari-server/ambari-audit.log | hdinsight 
 /var/log/ambari-server/ambari-server.log | hdinsight 
 /var/log/auth\* | agents, diagnostic, eg, normal, vmdiagnostic 
+/var/log/azure-cns\* | aks 
 /var/log/azure-npm.log | aks 
 /var/log/azure-vnet\* | aks 
 /var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.log | aks 
@@ -612,4 +613,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-04-21 14:37:16.296385`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-05-06 10:37:01.838628`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -144,6 +144,7 @@ aks | copy | /var/log/azure-vnet\*
 aks | copy | /var/run/azure-vnet\*
 aks | copy | /run/azure-vnet\*
 aks | copy | /etc/cni/net.d/\*.conflist
+aks | copy | /var/log/azure-cns\*
 aks | copy | /var/log/azure-npm.log
 aks | copy | /var/log/pods/kube-system\*/\*/\*.log
 aks | copy | /var/lib/docker/containers/\*/\*-json.log
@@ -1771,4 +1772,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-04-21 14:37:16.296385`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-05-06 10:37:01.838628`*

--- a/pyServer/manifests/linux/aks
+++ b/pyServer/manifests/linux/aks
@@ -23,6 +23,9 @@ copy,/var/run/azure-vnet*
 copy,/run/azure-vnet*
 copy,/etc/cni/net.d/*.conflist,noscan
 
+echo,### CNS logs ###
+copy,/var/log/azure-cns*,noscan
+
 echo,### NPM logs ###
 copy,/var/log/azure-npm.log,noscan
 


### PR DESCRIPTION
This PR adds CNS logs to diskinspect for AKS. This is necessary because if CNS is crashing, we have no way to get its logs without diskinspect, since CNS is responsible for setting up pod networking, and pod networking is required for things like `kubectl logs azure-cns ...`