### PR TITLE
The AKS manifest has been updated to include historical logs as well as Cilium and IPAM logs.

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -195,6 +195,7 @@ File Path | Manifest
 /var/log/ambari-server/ambari-server.log | hdinsight 
 /var/log/auth\* | agents, diagnostic, eg, normal, vmdiagnostic 
 /var/log/azure-cns\* | aks 
+/var/log/azure-ipam\* | aks 
 /var/log/azure-npm.log | aks 
 /var/log/azure-vnet\* | aks 
 /var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.log | aks 
@@ -215,6 +216,7 @@ File Path | Manifest
 /var/log/azure/kubelet-status.log | aks 
 /var/log/azure/run-command/handler.log | diagnostic, vmdiagnostic 
 /var/log/boot\* | diagnostic, eg, normal, vmdiagnostic 
+/var/log/cilium-cni\* | aks 
 /var/log/cloud-init\* | aks, diagnostic, diskpool, eg, normal, vmdiagnostic 
 /var/log/cloudregister | diagnostic 
 /var/log/diskpool-agent\* | diskpool 
@@ -619,8 +621,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-<<<<<<< HEAD
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 17:28:07.744805`*
-=======
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 15:22:47.261126`*
->>>>>>> The AKS manifest has been updated to "copy,/var/log/pods/kube-system*/*/*.log*" in order to add historical logs that are being written as .log.<date-created>
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-22 15:37:01.604293`*

--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -237,7 +237,7 @@ File Path | Manifest
 /var/log/kern\* | diagnostic, diskpool, eg, normal, vmdiagnostic 
 /var/log/messages\* | diagnostic, eg, monitor-mgmt, normal, vmdiagnostic 
 /var/log/nvidia\*.log | aks 
-/var/log/pods/kube-system\*/\*/\*.log | aks 
+/var/log/pods/kube-system\*/\*/\*.log\* | aks 
 /var/log/rsyslog\* | diagnostic, eg, lad, normal, vmdiagnostic 
 /var/log/s2\*.log | site-recovery 
 /var/log/sa/sa\* | performance 
@@ -619,4 +619,8 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
+<<<<<<< HEAD
 *File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 17:28:07.744805`*
+=======
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 15:22:47.261126`*
+>>>>>>> The AKS manifest has been updated to "copy,/var/log/pods/kube-system*/*/*.log*" in order to add historical logs that are being written as .log.<date-created>

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -146,7 +146,7 @@ aks | copy | /run/azure-vnet\*
 aks | copy | /etc/cni/net.d/\*.conflist
 aks | copy | /var/log/azure-cns\*
 aks | copy | /var/log/azure-npm.log
-aks | copy | /var/log/pods/kube-system\*/\*/\*.log
+aks | copy | /var/log/pods/kube-system\*/\*/\*.log\*
 aks | copy | /var/lib/docker/containers/\*/\*-json.log
 aks | copy | /var/log/nvidia\*.log
 aks | list | /var/log/pods/\*/\*
@@ -1794,4 +1794,8 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
+<<<<<<< HEAD
 *File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 17:28:07.744805`*
+=======
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 15:22:47.261126`*
+>>>>>>> The AKS manifest has been updated to "copy,/var/log/pods/kube-system*/*/*.log*" in order to add historical logs that are being written as .log.<date-created>

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -141,6 +141,8 @@ aks | copy | /var/log/azure/kern.log
 aks | copy | /var/log/journal/\*/\*
 aks | copy | /var/log/azure/containerd-status.log
 aks | copy | /var/log/azure-vnet\*
+aks | copy | /var/log/azure-ipam\*
+aks | copy | /var/log/cilium-cni\*
 aks | copy | /var/run/azure-vnet\*
 aks | copy | /run/azure-vnet\*
 aks | copy | /etc/cni/net.d/\*.conflist
@@ -1794,8 +1796,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-<<<<<<< HEAD
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 17:28:07.744805`*
-=======
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-19 15:22:47.261126`*
->>>>>>> The AKS manifest has been updated to "copy,/var/log/pods/kube-system*/*/*.log*" in order to add historical logs that are being written as .log.<date-created>
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2022-07-22 15:37:01.604293`*

--- a/manifests/linux/aks
+++ b/manifests/linux/aks
@@ -18,7 +18,9 @@ echo,### containerd ###
 copy,/var/log/azure/containerd-status.log
 
 echo,### CNI logs ###
-copy,/var/log/azure-vnet* 
+copy,/var/log/azure-vnet*
+copy,/var/log/azure-ipam*
+copy,/var/log/cilium-cni*
 copy,/var/run/azure-vnet*
 copy,/run/azure-vnet*
 copy,/etc/cni/net.d/*.conflist,noscan

--- a/manifests/linux/aks
+++ b/manifests/linux/aks
@@ -30,7 +30,7 @@ echo,### NPM logs ###
 copy,/var/log/azure-npm.log,noscan
 
 echo,### kube-system pod logs ###
-copy,/var/log/pods/kube-system*/*/*.log
+copy,/var/log/pods/kube-system*/*/*.log*
 copy,/var/lib/docker/containers/*/*-json.log
 
 echo,### NVidia installer logs for GPU nodes ###


### PR DESCRIPTION
Fixes AB#15010385 
The AKS manifest has been updated to ``"copy,/var/log/pods/kube-system*/*/*.log*"`` in order to add historical logs that are being written as `` .log.<date-created> ``

There has been also a change to include Cilium and IPAM logs in AKS manifest.