### PR TITLE
Updating list to include /etc/idmapd.conf

### DIFF
--- a/manifests/linux/diagnostic
+++ b/manifests/linux/diagnostic
@@ -143,6 +143,7 @@ copy,/etc/modprobe.d/*.conf,noscan
 copy,/etc/security/limits.conf,noscan
 copy,/etc/selinux/config,noscan
 copy,/sys/kernel/security/apparmor/profiles,noscan
+copy,/etc/idmapd.conf,noscan
 echo,
 
 echo,### Gathering Disk Info ###


### PR DESCRIPTION
This file is used in deployments that are setup with Azure NetAPP files and it's often asked to make sure it's configured correctly.
Reference: https://learn.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-configure-nfsv41-domain