### PR TITLE
Adding chrony.conf, imapd.conf and sshd dropin directory as proposed by previous PRs 

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -51,6 +51,7 @@ File Path | Manifest
 /etc/ambari-server/conf/\* | hdinsight 
 /etc/apt/sources.list | linux-repoconfig 
 /etc/apt/sources.list.d/\*.list | linux-repoconfig 
+/etc/chrony/chrony.conf | diagnostic 
 /etc/cloud/cloud.cfg | diagnostic, diskpool, eg, vmdiagnostic 
 /etc/cloud/cloud.cfg.d/\*.cfg | diagnostic, diskpool, eg, vmdiagnostic 
 /etc/cni/net.d/\*.conflist | aks 
@@ -67,6 +68,7 @@ File Path | Manifest
 /etc/hosts | diagnostic, hdinsight, linux-repoconfig 
 /etc/hosts.allow | diagnostic 
 /etc/hosts.deny | diagnostic 
+/etc/idmapd.conf | diagnostic 
 /etc/localtime | diagnostic 
 /etc/modprobe.d/\*.conf | diagnostic 
 /etc/netplan/\*.yaml | diagnostic, eg, vmdiagnostic 
@@ -88,6 +90,7 @@ File Path | Manifest
 /etc/selinux/config | diagnostic 
 /etc/spark/conf/\* | hdinsight 
 /etc/ssh/sshd_config | diagnostic, eg, normal, vmdiagnostic 
+/etc/ssh/sshd_config.d/\* | diagnostic 
 /etc/storm/conf/\* | hdinsight 
 /etc/sudoers | diagnostic 
 /etc/sudoers.d/\* | diagnostic 
@@ -126,17 +129,17 @@ File Path | Manifest
 /opt/msawb/var/log/\*/\*/\* | workloadbackup 
 /opt/msawb/var/log/\*/\*/\*/\*/\* | workloadbackup 
 /opt/mssql/bin/mssql-conf | sql-iaas 
-/run/NetworkManager/\*.conf | diagnostic, eg, vmdiagnostic 
-/run/NetworkManager/conf.d/\*.conf | diagnostic, eg, vmdiagnostic 
+/run/NetworkManager/\*.conf | eg, vmdiagnostic 
+/run/NetworkManager/conf.d/\*.conf | eg, vmdiagnostic 
 /run/azure-vnet\* | aks 
-/run/cloud-init/cloud.cfg | diagnostic, diskpool, eg, vmdiagnostic 
-/run/cloud-init/dhclient.hooks/\*.json | diagnostic, eg, vmdiagnostic 
-/run/cloud-init/ds-identify.log | diagnostic, diskpool, eg, vmdiagnostic 
-/run/cloud-init/result.json | diagnostic, diskpool, eg, vmdiagnostic 
-/run/cloud-init/status.json | diagnostic, diskpool, eg, vmdiagnostic 
-/run/resolvconf/\*.conf | diagnostic, eg, vmdiagnostic 
-/run/systemd/netif/leases/\* | diagnostic, eg, vmdiagnostic 
-/run/systemd/resolve/\*.conf | diagnostic, eg, vmdiagnostic 
+/run/cloud-init/cloud.cfg | diskpool, eg, vmdiagnostic 
+/run/cloud-init/dhclient.hooks/\*.json | eg, vmdiagnostic 
+/run/cloud-init/ds-identify.log | diskpool, eg, vmdiagnostic 
+/run/cloud-init/result.json | diskpool, eg, vmdiagnostic 
+/run/cloud-init/status.json | diskpool, eg, vmdiagnostic 
+/run/resolvconf/\*.conf | eg, vmdiagnostic 
+/run/systemd/netif/leases/\* | eg, vmdiagnostic 
+/run/systemd/resolve/\*.conf | eg, vmdiagnostic 
 /sys/kernel/security/apparmor/profiles | diagnostic 
 /tmp/omsagent\*.tgz | monitor-mgmt 
 /tmp/sosreport\*.tar.xz | linux-sos-scc 
@@ -634,4 +637,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-15 15:16:30.705733`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-15 18:53:03.293959`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -159,7 +159,6 @@ aks | copy | /var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.lo
 diagnostic | list | /boot
 diagnostic | list | /var/log
 diagnostic | list | /var/lib/cloud
-diagnostic | list | /run/cloud-init
 diagnostic | list | /var/lib/waagent
 diagnostic | list | /etc
 diagnostic | list | /etc/udev/rules.d
@@ -171,10 +170,6 @@ diagnostic | list | /usr/lib/systemd/user
 diagnostic | copy | /var/log/cloud-init\*
 diagnostic | copy | /etc/cloud/cloud.cfg
 diagnostic | copy | /etc/cloud/cloud.cfg.d/\*.cfg
-diagnostic | copy | /run/cloud-init/cloud.cfg
-diagnostic | copy | /run/cloud-init/ds-identify.log
-diagnostic | copy | /run/cloud-init/result.json
-diagnostic | copy | /run/cloud-init/status.json
 diagnostic | copy | /var/log/waagent\*
 diagnostic | copy | /etc/waagent.conf
 diagnostic | copy | /var/lib/waagent/provisioned
@@ -195,7 +190,6 @@ diagnostic | copy | /var/lib/waagent/SharedConfig.xml
 diagnostic | copy | /var/lib/waagent/history/\*.zip
 diagnostic | copy | /var/lib/waagent/\*/config/VMApp.lockfile
 diagnostic | copy | /var/lib/waagent/\*/config/applicationRegistry.active
-diagnostic | copy | /run/systemd/netif/leases/\*
 diagnostic | copy | /var/lib/NetworkManager/\*.lease
 diagnostic | copy | /var/lib/NetworkManager/\*.leases
 diagnostic | copy | /var/lib/wicked/lease\*
@@ -203,24 +197,20 @@ diagnostic | copy | /var/lib/dhclient/\*.lease
 diagnostic | copy | /var/lib/dhclient/\*.leases
 diagnostic | copy | /var/lib/dhcp/\*.lease
 diagnostic | copy | /var/lib/dhcp/\*.leases
-diagnostic | copy | /run/cloud-init/dhclient.hooks/\*.json
 diagnostic | copy | /etc/netplan/\*.yaml
 diagnostic | copy | /etc/dhcp/\*.conf
 diagnostic | copy | /etc/network/interfaces
 diagnostic | copy | /etc/network/interfaces.d/\*.cfg
 diagnostic | copy | /etc/ufw/ufw.conf
 diagnostic | copy | /etc/ssh/sshd_config
+diagnostic | copy | /etc/ssh/sshd_config.d/\*
 diagnostic | copy | /etc/nsswitch.conf
 diagnostic | copy | /etc/resolv.conf
-diagnostic | copy | /run/systemd/resolve/\*.conf
-diagnostic | copy | /run/resolvconf/\*.conf
 diagnostic | copy | /etc/hosts
 diagnostic | copy | /etc/hosts.allow
 diagnostic | copy | /etc/hosts.deny
 diagnostic | copy | /usr/lib/NetworkManager/\*.conf
 diagnostic | copy | /usr/lib/NetworkManager/conf.d/\*.conf
-diagnostic | copy | /run/NetworkManager/\*.conf
-diagnostic | copy | /run/NetworkManager/conf.d/\*.conf
 diagnostic | copy | /etc/NetworkManager/\*.conf
 diagnostic | copy | /etc/NetworkManager/conf.d/\*.conf
 diagnostic | copy | /var/lib/NetworkManager/\*.conf
@@ -259,6 +249,8 @@ diagnostic | copy | /etc/\*-release
 diagnostic | copy | /etc/HOSTNAME
 diagnostic | copy | /etc/hostname
 diagnostic | copy | /etc/localtime
+diagnostic | copy | /etc/chrony/chrony.conf
+diagnostic | copy | /etc/idmapd.conf
 diagnostic | copy | /etc/sudoers
 diagnostic | copy | /etc/sudoers.d/\*
 diagnostic | copy | /etc/sysctl.conf
@@ -1812,4 +1804,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-15 15:16:30.705733`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-15 18:53:03.293959`*

--- a/manifests/linux/diagnostic
+++ b/manifests/linux/diagnostic
@@ -126,7 +126,6 @@ copy,/etc/hostname,noscan
 copy,/etc/localtime,noscan
 copy,/etc/chrony/chrony.conf,noscan
 copy,/etc/idmapd.conf,noscan
-
 copy,/etc/sudoers,noscan
 copy,/etc/sudoers.d/*,noscan
 copy,/etc/sysctl.conf,noscan

--- a/manifests/linux/diagnostic
+++ b/manifests/linux/diagnostic
@@ -2,7 +2,6 @@ echo,### Probing Directories ###
 ll,/boot
 ll,/var/log
 ll,/var/lib/cloud
-ll,/run/cloud-init
 ll,/var/lib/waagent
 ll,/etc
 ll,/etc/udev/rules.d
@@ -16,10 +15,6 @@ echo,### Gathering Cloud-init Files ###
 copy,/var/log/cloud-init*
 copy,/etc/cloud/cloud.cfg
 copy,/etc/cloud/cloud.cfg.d/*.cfg
-copy,/run/cloud-init/cloud.cfg
-copy,/run/cloud-init/ds-identify.log
-copy,/run/cloud-init/result.json
-copy,/run/cloud-init/status.json
 echo,
 
 echo,### Gathering Waagent and Guest Extension Files ###
@@ -46,7 +41,6 @@ copy,/var/lib/waagent/*/config/applicationRegistry.active
 echo,
 
 echo,### Gathering Dhcp and Dhclient Files ###
-copy,/run/systemd/netif/leases/*,noscan
 copy,/var/lib/NetworkManager/*.lease,noscan
 copy,/var/lib/NetworkManager/*.leases,noscan
 copy,/var/lib/wicked/lease*,noscan
@@ -54,7 +48,6 @@ copy,/var/lib/dhclient/*.lease,noscan
 copy,/var/lib/dhclient/*.leases,noscan
 copy,/var/lib/dhcp/*.lease,noscan
 copy,/var/lib/dhcp/*.leases,noscan
-copy,/run/cloud-init/dhclient.hooks/*.json,noscan
 echo,
 
 echo,### Gathering Networking Files ###
@@ -64,10 +57,9 @@ copy,/etc/network/interfaces,noscan
 copy,/etc/network/interfaces.d/*.cfg,noscan
 copy,/etc/ufw/ufw.conf,noscan
 copy,/etc/ssh/sshd_config
+copy,/etc/ssh/sshd_config.d/*
 copy,/etc/nsswitch.conf,noscan
 copy,/etc/resolv.conf,noscan
-copy,/run/systemd/resolve/*.conf,noscan
-copy,/run/resolvconf/*.conf,noscan
 copy,/etc/hosts,noscan
 copy,/etc/hosts.allow,noscan
 copy,/etc/hosts.deny,noscan
@@ -76,8 +68,6 @@ echo,
 echo,### Gathering NetworkManager Files ###
 copy,/usr/lib/NetworkManager/*.conf,noscan
 copy,/usr/lib/NetworkManager/conf.d/*.conf,noscan
-copy,/run/NetworkManager/*.conf,noscan
-copy,/run/NetworkManager/conf.d/*.conf,noscan
 copy,/etc/NetworkManager/*.conf,noscan
 copy,/etc/NetworkManager/conf.d/*.conf,noscan
 copy,/var/lib/NetworkManager/*.conf,noscan
@@ -134,6 +124,9 @@ copy,/etc/*-release,noscan
 copy,/etc/HOSTNAME,noscan
 copy,/etc/hostname,noscan
 copy,/etc/localtime,noscan
+copy,/etc/chrony/chrony.conf,noscan
+copy,/etc/idmapd.conf,noscan
+
 copy,/etc/sudoers,noscan
 copy,/etc/sudoers.d/*,noscan
 copy,/etc/sysctl.conf,noscan


### PR DESCRIPTION
Adding chrony.conf, imapd.conf and sshd dropin directory as proposed by previous PRs 
Removed references to files in the /run filesystem, since /run is a RAM filesystem and files there are ephemeral, once the OS is down, the files are gone for good.