### PR TITLE
Added conf files for sshd, nfs, time sync and system startup files.

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -51,12 +51,13 @@ File Path | Manifest
 /etc/ambari-server/conf/\* | hdinsight 
 /etc/apt/sources.list | linux-repoconfig 
 /etc/apt/sources.list.d/\*.list | linux-repoconfig 
-/etc/chrony/chrony.conf | diagnostic 
+/etc/chrony/chrony.conf | diagnostic, vmdiagnostic 
 /etc/cloud/cloud.cfg | diagnostic, diskpool, eg, vmdiagnostic 
 /etc/cloud/cloud.cfg.d/\*.cfg | diagnostic, diskpool, eg, vmdiagnostic 
 /etc/cni/net.d/\*.conflist | aks 
 /etc/default/grub | linux-bootconfig 
 /etc/default/grub.d/\*.cfg | linux-bootconfig 
+/etc/dhclient\*.conf | vmdiagnostic 
 /etc/dhcp/\*.conf | diagnostic, eg, vmdiagnostic 
 /etc/dnf/dnf.conf | linux-repoconfig 
 /etc/dnf/vars/releasever | linux-repoconfig 
@@ -68,7 +69,7 @@ File Path | Manifest
 /etc/hosts | diagnostic, hdinsight, linux-repoconfig 
 /etc/hosts.allow | diagnostic 
 /etc/hosts.deny | diagnostic 
-/etc/idmapd.conf | diagnostic 
+/etc/idmapd.conf | diagnostic, vmdiagnostic 
 /etc/localtime | diagnostic 
 /etc/modprobe.d/\*.conf | diagnostic 
 /etc/netplan/\*.yaml | diagnostic, eg, vmdiagnostic 
@@ -91,6 +92,7 @@ File Path | Manifest
 /etc/spark/conf/\* | hdinsight 
 /etc/ssh/sshd_config | diagnostic, eg, normal, vmdiagnostic 
 /etc/ssh/sshd_config.d/\* | diagnostic 
+/etc/ssh/sshd_config.d/\*.conf | vmdiagnostic 
 /etc/storm/conf/\* | hdinsight 
 /etc/sudoers | diagnostic 
 /etc/sudoers.d/\* | diagnostic 
@@ -129,17 +131,17 @@ File Path | Manifest
 /opt/msawb/var/log/\*/\*/\* | workloadbackup 
 /opt/msawb/var/log/\*/\*/\*/\*/\* | workloadbackup 
 /opt/mssql/bin/mssql-conf | sql-iaas 
-/run/NetworkManager/\*.conf | eg, vmdiagnostic 
-/run/NetworkManager/conf.d/\*.conf | eg, vmdiagnostic 
+/run/NetworkManager/\*.conf | eg 
+/run/NetworkManager/conf.d/\*.conf | eg 
 /run/azure-vnet\* | aks 
-/run/cloud-init/cloud.cfg | diskpool, eg, vmdiagnostic 
-/run/cloud-init/dhclient.hooks/\*.json | eg, vmdiagnostic 
-/run/cloud-init/ds-identify.log | diskpool, eg, vmdiagnostic 
-/run/cloud-init/result.json | diskpool, eg, vmdiagnostic 
-/run/cloud-init/status.json | diskpool, eg, vmdiagnostic 
-/run/resolvconf/\*.conf | eg, vmdiagnostic 
-/run/systemd/netif/leases/\* | eg, vmdiagnostic 
-/run/systemd/resolve/\*.conf | eg, vmdiagnostic 
+/run/cloud-init/cloud.cfg | diskpool, eg 
+/run/cloud-init/dhclient.hooks/\*.json | eg 
+/run/cloud-init/ds-identify.log | diskpool, eg 
+/run/cloud-init/result.json | diskpool, eg 
+/run/cloud-init/status.json | diskpool, eg 
+/run/resolvconf/\*.conf | eg 
+/run/systemd/netif/leases/\* | eg 
+/run/systemd/resolve/\*.conf | eg 
 /sys/kernel/security/apparmor/profiles | diagnostic 
 /tmp/omsagent\*.tgz | monitor-mgmt 
 /tmp/sosreport\*.tar.xz | linux-sos-scc 
@@ -637,4 +639,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-15 18:53:03.293959`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-18 11:03:00.240571`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -518,16 +518,13 @@ sql-iaas | copy | /var/opt/mssql/log/\*.tar.gz2
 sql-iaas | copy | copy
 vmdiagnostic | list | /var/log
 vmdiagnostic | list | /var/lib/cloud
-vmdiagnostic | list | /run/cloud-init
 vmdiagnostic | list | /var/lib/waagent
 vmdiagnostic | list | /etc/udev/rules.d
+vmdiagnostic | list | /etc/systemd/system
+vmdiagnostic | list | /etc/systemd/system/multi-user.target.wants
 vmdiagnostic | copy | /var/log/cloud-init\*
 vmdiagnostic | copy | /etc/cloud/cloud.cfg
 vmdiagnostic | copy | /etc/cloud/cloud.cfg.d/\*.cfg
-vmdiagnostic | copy | /run/cloud-init/cloud.cfg
-vmdiagnostic | copy | /run/cloud-init/ds-identify.log
-vmdiagnostic | copy | /run/cloud-init/result.json
-vmdiagnostic | copy | /run/cloud-init/status.json
 vmdiagnostic | copy | /var/log/waagent\*
 vmdiagnostic | copy | /etc/waagent.conf
 vmdiagnostic | copy | /var/lib/waagent/provisioned
@@ -546,7 +543,6 @@ vmdiagnostic | copy | /var/lib/waagent/Incarnation
 vmdiagnostic | copy | /var/lib/waagent/ManagedIdentity-\*.json
 vmdiagnostic | copy | /var/lib/waagent/SharedConfig.xml
 vmdiagnostic | copy | /var/lib/waagent/history/\*.zip
-vmdiagnostic | copy | /run/systemd/netif/leases/\*
 vmdiagnostic | copy | /var/lib/NetworkManager/\*.lease
 vmdiagnostic | copy | /var/lib/NetworkManager/\*.leases
 vmdiagnostic | copy | /var/lib/wicked/lease\*
@@ -554,21 +550,20 @@ vmdiagnostic | copy | /var/lib/dhclient/\*.lease
 vmdiagnostic | copy | /var/lib/dhclient/\*.leases
 vmdiagnostic | copy | /var/lib/dhcp/\*.lease
 vmdiagnostic | copy | /var/lib/dhcp/\*.leases
-vmdiagnostic | copy | /run/cloud-init/dhclient.hooks/\*.json
+vmdiagnostic | copy | /etc/dhclient\*.conf
 vmdiagnostic | copy | /etc/netplan/\*.yaml
 vmdiagnostic | copy | /etc/dhcp/\*.conf
 vmdiagnostic | copy | /etc/network/interfaces
 vmdiagnostic | copy | /etc/network/interfaces.d/\*.cfg
 vmdiagnostic | copy | /etc/ufw/ufw.conf
 vmdiagnostic | copy | /etc/ssh/sshd_config
+vmdiagnostic | copy | /etc/ssh/sshd_config.d/\*.conf
 vmdiagnostic | copy | /etc/nsswitch.conf
 vmdiagnostic | copy | /etc/resolv.conf
-vmdiagnostic | copy | /run/systemd/resolve/\*.conf
-vmdiagnostic | copy | /run/resolvconf/\*.conf
+vmdiagnostic | copy | /etc/idmapd.conf
+vmdiagnostic | copy | /etc/chrony/chrony.conf
 vmdiagnostic | copy | /usr/lib/NetworkManager/\*.conf
 vmdiagnostic | copy | /usr/lib/NetworkManager/conf.d/\*.conf
-vmdiagnostic | copy | /run/NetworkManager/\*.conf
-vmdiagnostic | copy | /run/NetworkManager/conf.d/\*.conf
 vmdiagnostic | copy | /etc/NetworkManager/\*.conf
 vmdiagnostic | copy | /etc/NetworkManager/conf.d/\*.conf
 vmdiagnostic | copy | /var/lib/NetworkManager/\*.conf
@@ -1804,4 +1799,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-15 18:53:03.293959`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-09-18 11:03:00.240571`*

--- a/manifests/linux/vmdiagnostic
+++ b/manifests/linux/vmdiagnostic
@@ -1,18 +1,15 @@
 echo,### Probing Directories ###
 ll,/var/log
 ll,/var/lib/cloud
-ll,/run/cloud-init
 ll,/var/lib/waagent
 ll,/etc/udev/rules.d
+ll,/etc/systemd/system
+ll,/etc/systemd/system/multi-user.target.wants
 
 echo,### Gathering Cloud-init Files ###
 copy,/var/log/cloud-init*
 copy,/etc/cloud/cloud.cfg
 copy,/etc/cloud/cloud.cfg.d/*.cfg
-copy,/run/cloud-init/cloud.cfg
-copy,/run/cloud-init/ds-identify.log
-copy,/run/cloud-init/result.json
-copy,/run/cloud-init/status.json
 echo,
 
 echo,### Gathering Waagent and Guest Extension Files ###
@@ -37,7 +34,6 @@ copy,/var/lib/waagent/history/*.zip,noscan
 echo,
 
 echo,### Gathering Dhcp and Dhclient Files ###
-copy,/run/systemd/netif/leases/*
 copy,/var/lib/NetworkManager/*.lease
 copy,/var/lib/NetworkManager/*.leases
 copy,/var/lib/wicked/lease*
@@ -45,27 +41,26 @@ copy,/var/lib/dhclient/*.lease
 copy,/var/lib/dhclient/*.leases
 copy,/var/lib/dhcp/*.lease
 copy,/var/lib/dhcp/*.leases
-copy,/run/cloud-init/dhclient.hooks/*.json
 echo,
 
 echo,### Gathering Networking Files ###
+copy,/etc/dhclient*.conf
 copy,/etc/netplan/*.yaml
 copy,/etc/dhcp/*.conf
 copy,/etc/network/interfaces
 copy,/etc/network/interfaces.d/*.cfg
 copy,/etc/ufw/ufw.conf
 copy,/etc/ssh/sshd_config
+copy,/etc/ssh/sshd_config.d/*.conf
 copy,/etc/nsswitch.conf
 copy,/etc/resolv.conf
-copy,/run/systemd/resolve/*.conf
-copy,/run/resolvconf/*.conf
+copy,/etc/idmapd.conf
+copy,/etc/chrony/chrony.conf
 echo,
 
 echo,### Gathering NetworkManager Files ###
 copy,/usr/lib/NetworkManager/*.conf
 copy,/usr/lib/NetworkManager/conf.d/*.conf
-copy,/run/NetworkManager/*.conf
-copy,/run/NetworkManager/conf.d/*.conf
 copy,/etc/NetworkManager/*.conf
 copy,/etc/NetworkManager/conf.d/*.conf
 copy,/var/lib/NetworkManager/*.conf


### PR DESCRIPTION
Added: 
- chrony.conf, idmapd.conf and sshd drop-in directory,
- boot configuration files used in RHEL8 and above.

Listed:
- systemd startup configuration files.

Removed:
- files from /run filesystem, /run filesystem is a RAM based one and files will not be available during the IaaS diagnostics collection.

These files facilitate diagnosis of time synchronization, NFS, sshd connectivity and system startup issues.