### PR TITLE
Updated aks manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -173,7 +173,6 @@ File Path | Manifest
 /var/lib/dhclient/\*.leases | diagnostic, eg, vmdiagnostic 
 /var/lib/dhcp/\*.lease | diagnostic, eg, vmdiagnostic 
 /var/lib/dhcp/\*.leases | diagnostic, eg, vmdiagnostic 
-/var/lib/docker/containers/\*/\*-json.log | aks 
 /var/lib/waagent/ExtensionsConfig.\*.xml | diagnostic, lad, vmdiagnostic 
 /var/lib/waagent/GoalState.\*.xml | diagnostic, site-recovery, vmdiagnostic, workloadbackup 
 /var/lib/waagent/HostingEnvironmentConfig.xml | diagnostic, vmdiagnostic 
@@ -272,9 +271,10 @@ File Path | Manifest
 /var/log/kern\* | diagnostic, diskpool, eg, normal, vmdiagnostic 
 /var/log/messages\* | azuremonitoragent, diagnostic, eg, monitor-mgmt, normal, vmdiagnostic 
 /var/log/nvidia\*.log | aks 
-/var/log/pods/calico-system/\*/\*.log\* | aks 
+/var/log/pods/calico-system\*/\*/\*.log\* | aks 
 /var/log/pods/kube-system\*/\*/\*.log\* | aks 
-/var/log/pods/tigera-operator/\*/\*.log\* | aks 
+/var/log/pods/kured\*/\*/\*.log\* | aks 
+/var/log/pods/tigera-operator\*/\*/\*.log\* | aks 
 /var/log/rsyslog\* | diagnostic, eg, lad, normal, vmdiagnostic 
 /var/log/s2\*.log | site-recovery 
 /var/log/sa/sa\* | performance 
@@ -662,4 +662,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-10-03 13:47:16.735303`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-11-01 11:36:24.463055`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -150,9 +150,9 @@ aks | copy | /etc/cni/net.d/\*.conflist
 aks | copy | /var/log/azure-cns\*
 aks | copy | /var/log/azure-npm.log
 aks | copy | /var/log/pods/kube-system\*/\*/\*.log\*
-aks | copy | /var/log/pods/calico-system/\*/\*.log\*
-aks | copy | /var/log/pods/tigera-operator/\*/\*.log\*
-aks | copy | /var/lib/docker/containers/\*/\*-json.log
+aks | copy | /var/log/pods/calico-system\*/\*/\*.log\*
+aks | copy | /var/log/pods/tigera-operator\*/\*/\*.log\*
+aks | copy | /var/log/pods/kured\*/\*/\*.log\*
 aks | copy | /var/log/nvidia\*.log
 aks | list | /var/log/pods/\*/\*
 aks | copy | /var/log/azure/Microsoft.AKS.Compute.AKS.Linux.AKSNode/extension.log
@@ -1827,4 +1827,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-10-03 13:47:16.735303`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2023-11-01 11:36:24.463055`*

--- a/manifests/linux/aks
+++ b/manifests/linux/aks
@@ -34,9 +34,9 @@ copy,/var/log/azure-npm.log,noscan
 
 echo,### kube-system pod logs ###
 copy,/var/log/pods/kube-system*/*/*.log*
-copy,/var/log/pods/calico-system/*/*.log*
-copy,/var/log/pods/tigera-operator/*/*.log*
-copy,/var/lib/docker/containers/*/*-json.log
+copy,/var/log/pods/calico-system*/*/*.log*
+copy,/var/log/pods/tigera-operator*/*/*.log*
+copy,/var/log/pods/kured*/*/*.log*
 
 echo,### NVidia installer logs for GPU nodes ###
 copy,/var/log/nvidia*.log,noscan


### PR DESCRIPTION


**Change set:**

* we don't use Docker anymore
* fixed calico and tigera logs
* added kured

**Issue reproduction:**

The logs were not exported for calico, tigera and kured.

![image](https://github.com/Azure/azure-diskinspect-service/assets/839542/5572029e-19e9-437c-adea-ff306b1f61b1)

**Test:**

Tested with [kvaps/kubectl-node-shell: Exec into node via kubectl (github.com)](https://github.com/kvaps/kubectl-node-shell) on the vmss in AKS

![image](https://github.com/Azure/azure-diskinspect-service/assets/839542/a5d8eeeb-282a-42cc-ace9-bb5bc9009e70)

