### PR TITLE
Removing specific files in /etc/sysconfig/network 

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -116,10 +116,10 @@ File Path | Manifest
 /etc/sysconfig/network-scripts/ifcfg-\* | diagnostic, eg, vmdiagnostic 
 /etc/sysconfig/network-scripts/ifcfg-eth0 | normal 
 /etc/sysconfig/network-scripts/route-\* | diagnostic, eg, vmdiagnostic 
-/etc/sysconfig/network/config | diagnostic, eg, vmdiagnostic 
-/etc/sysconfig/network/dhcp | diagnostic, eg, vmdiagnostic 
-/etc/sysconfig/network/ifcfg-\* | diagnostic, eg, vmdiagnostic 
-/etc/sysconfig/network/routes | diagnostic, eg, vmdiagnostic 
+/etc/sysconfig/network/config | eg, vmdiagnostic 
+/etc/sysconfig/network/dhcp | eg, vmdiagnostic 
+/etc/sysconfig/network/ifcfg-\* | eg, vmdiagnostic 
+/etc/sysconfig/network/routes | eg, vmdiagnostic 
 /etc/sysctl.conf | diagnostic 
 /etc/sysctl.d/\*.conf | diagnostic 
 /etc/syslog-ng/\* | azuremonitoragent 
@@ -673,4 +673,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-06-24 15:04:03.189644`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-07-22 15:12:48.366181`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -247,13 +247,9 @@ diagnostic | copy | /etc/NetworkManager/conf.d/\*.conf
 diagnostic | copy | /var/lib/NetworkManager/\*.conf
 diagnostic | copy | /var/lib/NetworkManager/conf.d/\*.conf
 diagnostic | copy | /var/lib/NetworkManager/\*.state
-diagnostic | copy | /etc/sysconfig/network/dhcp
 diagnostic | copy | /etc/sysconfig/network
 diagnostic | copy | /etc/sysconfig/network-scripts/ifcfg-\*
 diagnostic | copy | /etc/sysconfig/network-scripts/route-\*
-diagnostic | copy | /etc/sysconfig/network/config
-diagnostic | copy | /etc/sysconfig/network/ifcfg-\*
-diagnostic | copy | /etc/sysconfig/network/routes
 diagnostic | copy | /etc/sysconfig/iptables
 diagnostic | copy | /etc/sysconfig/SuSEfirewall2
 diagnostic | copy | /etc/wicked/\*.xml
@@ -1842,4 +1838,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-06-24 15:04:03.189644`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-07-22 15:12:48.366181`*

--- a/manifests/linux/diagnostic
+++ b/manifests/linux/diagnostic
@@ -78,13 +78,9 @@ copy,/var/lib/NetworkManager/*.state,noscan
 echo,
 
 echo,### Gathering Sysconfig Network Files ###
-copy,/etc/sysconfig/network/dhcp,noscan
 copy,/etc/sysconfig/network,noscan
 copy,/etc/sysconfig/network-scripts/ifcfg-*,noscan
 copy,/etc/sysconfig/network-scripts/route-*,noscan
-copy,/etc/sysconfig/network/config,noscan
-copy,/etc/sysconfig/network/ifcfg-*,noscan
-copy,/etc/sysconfig/network/routes,noscan
 copy,/etc/sysconfig/iptables,noscan
 copy,/etc/sysconfig/SuSEfirewall2,noscan
 echo,


### PR DESCRIPTION
The manifest already included the whole /etc/sysconfig/network directory, hence adding individual files to the manifest was adding an extra subdirectory layer causing the /etc/sysconfig/network directory to be copied under the /etc/sysconfig/network/network subdirectory.

