### PR TITLE
Adding deb822 format for sources, used in Ubuntu 24.04

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -52,6 +52,7 @@ File Path | Manifest
 /etc/ambari-server/conf/\* | hdinsight 
 /etc/apt/sources.list | linux-repoconfig 
 /etc/apt/sources.list.d/\*.list | linux-repoconfig 
+/etc/apt/sources.list.d/\*.sources | linux-repoconfig 
 /etc/chrony/chrony.conf | diagnostic, vmdiagnostic 
 /etc/cloud/cloud.cfg | diagnostic, diskpool, eg, vmdiagnostic 
 /etc/cloud/cloud.cfg.d/\*.cfg | diagnostic, diskpool, eg, vmdiagnostic 
@@ -678,4 +679,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-06 11:11:49.836003`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-11 14:57:31.185418`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -453,6 +453,7 @@ linux-repoconfig | copy | /etc/dnf/vars/releasever
 linux-repoconfig | copy | /etc/yum.repos.d/rh-cloud-rhel\*.repo
 linux-repoconfig | copy | /etc/apt/sources.list
 linux-repoconfig | copy | /etc/apt/sources.list.d/\*.list
+linux-repoconfig | copy | /etc/apt/sources.list.d/\*.sources
 linux-repoconfig | copy | /etc/hosts
 linux-repoconfig | copy | /var/log/rhuicheck.log
 linux-sos-scc | list | /var/tmp
@@ -1844,4 +1845,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-06 11:11:49.836003`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-11 14:57:31.185418`*

--- a/manifests/linux/linux-repoconfig
+++ b/manifests/linux/linux-repoconfig
@@ -16,5 +16,6 @@ copy,/etc/dnf/vars/releasever,noscan
 copy,/etc/yum.repos.d/rh-cloud-rhel*.repo
 copy,/etc/apt/sources.list,noscan
 copy,/etc/apt/sources.list.d/*.list,noscan
+copy,/etc/apt/sources.list.d/*.sources,noscan
 copy,/etc/hosts,noscan
 copy,/var/log/rhuicheck.log


### PR DESCRIPTION
Ubuntu 24.04 added a new format of apt config with extension .sources.
This is documented here.
https://manpages.ubuntu.com/manpages/oracular/en/man5/sources.list.5.html