### PR TITLE
Add SQL Writer log to capture for SQL IaaS

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -422,6 +422,7 @@ File Path | Manifest
 /Program Files/Microsoft Monitoring Agent/Agent/Health Service State/FCT_\*/work/loca<br>lhost.mof | monitor-mgmt 
 /Program Files/Microsoft Monitoring Agent/Agent/Health Service State/FCT_\*/work/loca<br>lhost.prevmof | monitor-mgmt 
 /Program Files/Microsoft Monitoring Agent/Agent/Health Service State/Management Packs<br>/\*.xml | monitor-mgmt 
+/Program Files/Microsoft SQL Server/90/Shared/SqlWriterLogger\*.txt | sql-iaas 
 /Program Files/Microsoft SQL Server/\*/MSSQL/Log/ERRORLOG | sql-iaas 
 /Program Files/Microsoft SQL Server/\*/MSSQL/Log/ERRORLOG.\* | sql-iaas 
 /Program Files/Microsoft SQL Server/\*/MSSQL/Log/ExtensibilityLog/ExtensibilityLog/EX<br>TLAUNCHERRORLOG | sql-iaas 
@@ -679,4 +680,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-11 14:57:31.185418`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-24 14:50:17.425615`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -1403,6 +1403,7 @@ sql-iaas | copy | /Program Files/Microsoft SQL Server/\*/MSSQL/Log/\*.log
 sql-iaas | copy | /Program Files/Microsoft SQL Server/\*/MSSQL/Log/\*.mdmp
 sql-iaas | copy | /Program Files/Microsoft SQL Server/\*/Setup Bootstrap/Log/\*/Log\*.cab
 sql-iaas | copy | /Program Files/Microsoft SQL Server/\*/Setup Bootstrap/Log/Summary.txt
+sql-iaas | copy | /Program Files/Microsoft SQL Server/90/Shared/SqlWriterLogger\*.txt
 vmdiagnostic | copy | /Windows/System32/config/SOFTWARE
 vmdiagnostic | copy | /Windows/System32/config/SYSTEM
 vmdiagnostic | copy | /Windows/System32/winevt/Logs/System.evtx
@@ -1845,4 +1846,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-11 14:57:31.185418`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-09-24 14:50:17.425615`*

--- a/manifests/windows/sql-iaas
+++ b/manifests/windows/sql-iaas
@@ -38,3 +38,4 @@ copy,/Program Files/Microsoft SQL Server/*/MSSQL/Log/*.log
 copy,/Program Files/Microsoft SQL Server/*/MSSQL/Log/*.mdmp,noscan
 copy,/Program Files/Microsoft SQL Server/*/Setup Bootstrap/Log/*/Log*.cab,noscan
 copy,/Program Files/Microsoft SQL Server/*/Setup Bootstrap/Log/Summary.txt
+copy,/Program Files/Microsoft SQL Server/90/Shared/SqlWriterLogger*.txt


### PR DESCRIPTION
A new log introduced by SQL Server 2019 (15.x) to provide better visibility on its SQLWriter operations. This functionality was also made available in SQL Server 2016 (13.x) Service Pack 3, and SQL Server 2017 (14.x) Cumulative Update (CU) 27.

Azure Backup for VM and Azure Site Recovery use VSS for backups and therefore including this file will help with investigation of these types of cases with the collection of the logs and not needing to ask the customer to provide the data thereby speeding up case resolution. 

The file paths are fixed regardless of SQL Server version to:

1. C:\Program Files\Microsoft SQL Server\90\Shared\SqlWriterLogger.txt
2. C:\Program Files\Microsoft SQL Server\90\Shared\SqlWriterLogger1.txt

I believe my wildcard (e.g. copy,/Program Files/Microsoft SQL Server/90/Shared/SqlWriterLogger*.txt) will find either/both of these files if they exist. 