### PR TITLE
vmdiagnostic: collect /var/log/journal

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -288,7 +288,7 @@ File Path | Manifest
 /var/log/hdinsight-startupagent/hdinsight-startupagent.out | hdinsight 
 /var/log/hive/hivemetastore.log | hdinsight 
 /var/log/hive/hiveserver2.log | hdinsight 
-/var/log/journal/\*/\* | aks 
+/var/log/journal/\*/\* | aks, vmdiagnostic 
 /var/log/kern.log | servicefabric 
 /var/log/kern\* | diagnostic, diskpool, eg, normal, vmdiagnostic 
 /var/log/messages\* | azuremonitoragent, diagnostic, eg, monitor-mgmt, normal, vmdiagnostic 
@@ -717,4 +717,4 @@ File Path | Manifest
 /k/kubeclusterconfig.json | aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-11-07 23:24:30.047485`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-01-09 17:15:50.960566`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -641,6 +641,7 @@ vmdiagnostic | copy | /var/log/dmesg\*
 vmdiagnostic | copy | /var/log/boot\*
 vmdiagnostic | copy | /var/log/auth\*
 vmdiagnostic | copy | /var/log/secure\*
+vmdiagnostic | copy | /var/log/journal/\*/\*
 vmdiagnostic | copy | /var/log/azure/\*/\*
 vmdiagnostic | copy | /var/log/azure/\*/\*/\*
 vmdiagnostic | copy | /var/log/azure/custom-script/handler.log
@@ -1886,4 +1887,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2024-11-07 23:24:30.047485`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-01-09 17:15:50.960566`*

--- a/manifests/linux/vmdiagnostic
+++ b/manifests/linux/vmdiagnostic
@@ -99,6 +99,7 @@ copy,/var/log/dmesg*
 copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*
+copy,/var/log/journal/*/*,noscan
 echo,
 
 echo,### Gathering Azure Files ###

--- a/manifests/linux/vmdiagnostic
+++ b/manifests/linux/vmdiagnostic
@@ -99,7 +99,7 @@ copy,/var/log/dmesg*
 copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*
-copy,/var/log/journal/*/*,noscan
+copy,/var/log/journal/*/*
 echo,
 
 echo,### Gathering Azure Files ###


### PR DESCRIPTION
The journal has the most detailed system logs.  This matches the configuration used by the aks manifest to collect it.