### PR TITLE
Adding AKS Windows logs to IID manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -338,7 +338,7 @@ File Path | Manifest
 /$Windows.~BT/Sources/Panther/setupact.log | windowsupdate 
 /$Windows.~BT/Sources/Panther/setuperr.log | windowsupdate 
 /AzureData/CustomDataSetupScript.log | aks 
-/AzureData/CustomDataSetupScript.ps1 | aks 
+/AzureData/NvidiaInstallLog/\*.log | aks 
 /Boot/BCD | windowsupdate 
 /CalicoWindows/logs/\*.log | aks 
 /Packages/Plugins/ESET.FileSecurity/\*/agent_version.txt | agents, diagnostic, normal, vmdiagnostic, windowsupdate 
@@ -725,8 +725,13 @@ File Path | Manifest
 /WindowsAzure/Logs/VFPlugin/\*.log | monitor-mgmt 
 /WindowsAzure/Logs/WaAppAgent.log | agents, diagnostic, eg, min-diagnostic, normal, site-recovery, vmdiagnostic, windowsupdate, workloadbackup 
 /WindowsAzure/Logs/\*.log | monitor-mgmt 
+/WindowsAzure/Logs/aks/\*.dmp | aks 
+/WindowsAzure/Logs/aks/\*.log | aks 
+/WindowsAzure/Logs/aks/\*.txt | aks 
 /WindowsAzure/Logs/plugins/\*/\*/\*.log | monitor-mgmt 
 /WindowsAzure/ProxyAgent/Logs/\* | agents, diagnostic, min-diagnostic, normal 
+/WindowsAzure/TransparentInstaller.log | aks 
+/WindowsAzure/WaAppAgent.log | aks 
 /WindowsAzure/config/\*.xml | agents, diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 /WindowsUpdateVerbose.etl | windowsupdate 
 /k/\*.err | aks 
@@ -735,9 +740,12 @@ File Path | Manifest
 /k/azure-vnet-ipam.log | aks 
 /k/azure-vnet.json | aks 
 /k/azure-vnet.log | aks 
+/k/azurecni/netconf/10-azure.conflist | aks 
+/k/azurecns/\*.json | aks 
+/k/azurecns/\*.log | aks 
 /k/bootstrap-config | aks 
-/k/kubeclusterconfig.json | aks 
+/k/kubeclusterconfig.json | aks, aks 
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 /windows/Panther/setup.etl | diagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-03-10 13:50:47.376270`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-03-18 12:25:25.128179`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -821,7 +821,12 @@ aks | copy | /Windows/System32/winevt/Logs/Application.evtx
 aks | copy | /k/\*.log
 aks | copy | /k/\*.err
 aks | copy | /k/kubeclusterconfig.json
+aks | copy | /k/azurecni/netconf/10-azure.conflist
+aks | copy | /k/azurecns/\*.log
+aks | copy | /k/azurecns/\*.json
+aks | copy | /k/kubeclusterconfig.json
 aks | copy | /Program Files/containerd/config.toml
+aks | copy | /AzureData/NvidiaInstallLog/\*.log
 aks | copy | /k/bootstrap-config
 aks | copy | /k/azure-vnet.log
 aks | copy | /k/azure-vnet-ipam.log
@@ -834,9 +839,13 @@ aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Host-Network-Servic
 aks | copy | /CalicoWindows/logs/\*.log
 aks | copy | /ProgramData/containerd/root/panic.log
 aks | copy | /AzureData/CustomDataSetupScript.log
-aks | copy | /AzureData/CustomDataSetupScript.ps1
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-Windows-Containers-CCG%4Admin.evtx
 aks | copy | /Windows/System32/winevt/Logs/Microsoft-AKSGMSAPlugin%4Admin.evtx
+aks | copy | /WindowsAzure/TransparentInstaller.log
+aks | copy | /WindowsAzure/WaAppAgent.log
+aks | copy | /WindowsAzure/Logs/aks/\*.log
+aks | copy | /WindowsAzure/Logs/aks/\*.txt
+aks | copy | /WindowsAzure/Logs/aks/\*.dmp
 asc-vmhealth | copy | /WindowsAzure/Logs/TransparentInstaller.log
 diagnostic | copy | /Windows/System32/config/SOFTWARE
 diagnostic | copy | /Windows/System32/config/SYSTEM
@@ -1927,4 +1936,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-03-10 13:50:47.376270`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-03-18 12:25:25.128179`*

--- a/manifests/windows/aks
+++ b/manifests/windows/aks
@@ -53,8 +53,8 @@ echo,### WindowsAzure GuestAgent logs ###
 copy,/WindowsAzure/TransparentInstaller.log
 copy,/WindowsAzure/WaAppAgent.log
 copy,/WindowsAzure/Logs/aks/*.log
-copy./WindowsAzure/Logs/aks/*.txt
+copy,/WindowsAzure/Logs/aks/*.txt
 
-echo,### Last bugcheck minidump (less than 10MB) ###
+echo,### Last bugcheck minidump ###
 copy,/WindowsAzure/Logs/aks/*.dmp
 

--- a/manifests/windows/aks
+++ b/manifests/windows/aks
@@ -5,10 +5,21 @@ copy,/Windows/System32/winevt/Logs/Application.evtx
 echo,### Logs of services including but not limited to Kubelet, Kube proxy and containerd ###
 copy,/k/*.log
 copy,/k/*.err
+copy,/k/kubeclusterconfig.json
+
+echo,### AzureCNI config ###
+copy,/k/azurecni/netconf/10-azure.conflist
+
+echo,### AzureCNS logs ###
+copy,/k/azurecns/*.log
+copy,/k/azurecns/*.json
 
 echo,### Cluster configurations ###
 copy,/k/kubeclusterconfig.json
 copy,/Program Files/containerd/config.toml
+
+echo,### Nvidia logs ###
+copy,/AzureData/NvidiaInstallLog/*.log
 
 echo,### Kubelet bootstrap config ###
 copy,/k/bootstrap-config
@@ -33,10 +44,17 @@ copy,/ProgramData/containerd/root/panic.log,noscan
 
 echo,### Cluster provision logs ###
 copy,/AzureData/CustomDataSetupScript.log
-copy,/AzureData/CustomDataSetupScript.ps1
 
 echo,### Windows CCGPlugin logs ###
 copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Containers-CCG%4Admin.evtx
 copy,/Windows/System32/winevt/Logs/Microsoft-AKSGMSAPlugin%4Admin.evtx
 
+echo,### WindowsAzure GuestAgent logs ###
+copy,/WindowsAzure/TransparentInstaller.log
+copy,/WindowsAzure/WaAppAgent.log
+copy,/WindowsAzure/Logs/aks/*.log
+copy./WindowsAzure/Logs/aks/*.txt
+
+echo,### Last bugcheck minidump (less than 10MB) ###
+copy,/WindowsAzure/Logs/aks/*.dmp
 


### PR DESCRIPTION
For troubleshooting purposes and TTM reduction.

To mimic collect-windows-logs.ps1, adding the following files to the manifest:

kubeclusterconfig.json
CNI and CNS logs
NVIDIA driver installation logs
WAAGENT logs
last bugcheck minidump*
if less than 10 MBs. A ScheduledTask on the windows node will validate if a minidump exists and if it's less than 10 MBs in size, it'll be copied over to C:/WindowsAzure/Logs/aks/*.dmp