### PR TITLE
Added azure-cni logs to IID AKS Linux manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -234,6 +234,7 @@ File Path | Manifest
 /var/log/ambari-server/ambari-audit.log | hdinsight 
 /var/log/ambari-server/ambari-server.log | hdinsight 
 /var/log/auth\* | agents, diagnostic, eg, normal, vmdiagnostic 
+/var/log/azure-cni\* | aks 
 /var/log/azure-cns\* | aks 
 /var/log/azure-ipam\* | aks 
 /var/log/azure-npm.log | aks 
@@ -748,4 +749,4 @@ File Path | Manifest
 /unattend.xml | diagnostic, eg, normal, vmdiagnostic, windowsupdate 
 /windows/Panther/setup.etl | diagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-03-18 12:25:25.128179`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-04-09 11:17:09.256164`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -142,6 +142,7 @@ aks | copy | /var/log/azure/kubelet-status.log
 aks | copy | /var/log/azure/kern.log
 aks | copy | /var/log/journal/\*/\*
 aks | copy | /var/log/azure/containerd-status.log
+aks | copy | /var/log/azure-cni\*
 aks | copy | /var/log/azure-vnet\*
 aks | copy | /var/log/azure-ipam\*
 aks | copy | /var/log/cilium-cni\*
@@ -1936,4 +1937,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-03-18 12:25:25.128179`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-04-09 11:17:09.256164`*

--- a/manifests/linux/aks
+++ b/manifests/linux/aks
@@ -19,6 +19,7 @@ echo,### containerd ###
 copy,/var/log/azure/containerd-status.log
 
 echo,### CNI logs ###
+copy,/var/log/azure-cni*
 copy,/var/log/azure-vnet*
 copy,/var/log/azure-ipam*
 copy,/var/log/cilium-cni*


### PR DESCRIPTION
This change adds azure-cni* logs to the manifest, matching the aks-log-collector behavior.
(https://github.com/Azure/AgentBaker/blob/47209249a37c2e232285592d3af398184e5879b8/parts/linux/cloud-init/artifacts/aks-log-collector.sh#L174-L180). 

