### PR TITLE
Added Azure Backup (dataprotection-manager) logs to IID AKS Linux manifest

### DIFF
--- a/docs/manifest_by_file.md
+++ b/docs/manifest_by_file.md
@@ -340,6 +340,7 @@ File Path | Manifest
 /var/log/pacemaker/\* | diagnostic 
 /var/log/pacemaker\* | diagnostic 
 /var/log/pods/calico-system\*/\*/\*.log\* | aks 
+/var/log/pods/dataprotection-microsoft\*/\*/\*.log\* | aks 
 /var/log/pods/kube-system\*/\*/\*.log\* | aks 
 /var/log/pods/kured\*/\*/\*.log\* | aks 
 /var/log/pods/tigera-operator\*/\*/\*.log\* | aks 
@@ -885,4 +886,4 @@ File Path | Manifest
 /var/log/blobfuse2.log\* | diagnostic 
 /windows/Panther/setup.etl | diagnostic, windowsupdate 
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-07-17 07:32:49.301613`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-08-07 12:18:10.438501`*

--- a/docs/manifest_content.md
+++ b/docs/manifest_content.md
@@ -155,6 +155,7 @@ aks | copy | /var/log/pods/kube-system\*/\*/\*.log\*
 aks | copy | /var/log/pods/calico-system\*/\*/\*.log\*
 aks | copy | /var/log/pods/tigera-operator\*/\*/\*.log\*
 aks | copy | /var/log/pods/kured\*/\*/\*.log\*
+aks | copy | /var/log/pods/dataprotection-microsoft\*/\*/\*.log\*
 aks | copy | /var/log/blobfuse2.log
 aks | copy | /var/log/blobfuse2.log\*
 aks | copy | /var/log/nvidia\*.log
@@ -2106,4 +2107,4 @@ workloadbackup | copy | /WindowsAzure/Logs/Plugins/\*
 workloadbackup | copy | /WindowsAzure/Logs/AggregateStatus/aggregatestatus\*.json
 workloadbackup | copy | /WindowsAzure/Logs/AppAgentRuntime.log
 
-*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-07-17 07:32:49.301613`*
+*File was created by running [parse_manifest.py](../tools/parse_manifest.py) on `2025-08-07 12:18:10.438501`*

--- a/manifests/linux/aks
+++ b/manifests/linux/aks
@@ -39,10 +39,12 @@ copy,/var/log/pods/calico-system*/*/*.log*
 copy,/var/log/pods/tigera-operator*/*/*.log*
 copy,/var/log/pods/kured*/*/*.log*
 
+echo,### dataprotection-microsoft pod logs ###
+copy,/var/log/pods/dataprotection-microsoft*/*/*.log*
+
 echo,## Blob Fuse ##
 copy,/var/log/blobfuse2.log
 copy,/var/log/blobfuse2.log*
-echo,
 
 echo,### NVidia installer logs for GPU nodes ###
 copy,/var/log/nvidia*.log,noscan


### PR DESCRIPTION
Despite being an AKS-managed addon, IID is not currently retrieving these container logs as by default they're placed on their own namespace (dataprotection-manager) as opposed to kube-system.

This PR adds DPM logs to IID, allowing support and engineering to retrieve logs for troubleshooting