### PR TITLE
Prototype of modules for WindowsUpdate and OSUpgrade

### DIFF
--- a/docs/manifests/windows/diagnostic-eventlogs.md
+++ b/docs/manifests/windows/diagnostic-eventlogs.md
@@ -1,0 +1,55 @@
+# Windows Event Logs Diagnostic Manifests
+
+Modular manifests for collecting Windows Event Logs.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-eventlogs-general-common` | System, Application, Setup logs | 25-150 MB | Low |
+| `diagnostic-eventlogs-client-windowsupdate` | Windows Update client events | 5-50 MB | None |
+| `diagnostic-eventlogs-do-windowsupdate` | Delivery Optimization, BITS | 5-30 MB | None |
+| `diagnostic-eventlogs-setup-osupgrade` | Setup, Upgrade Diagnostics | 5-50 MB | None |
+| `diagnostic-eventlogs-taskscheduler-common` | Task Scheduler operational | 5-30 MB | None |
+| `diagnostic-eventlogs-kernel-common` | Kernel PnP, Power events | 5-30 MB | None |
+| `diagnostic-eventlogs-security-common` | CAPI2, Licensing events | 5-30 MB | Low |
+| `diagnostic-eventlogs-grouppolicy-common` | Group Policy operational | 5-20 MB | None |
+
+## File Locations
+
+### diagnostic-eventlogs-general-common
+```
+/Windows/System32/winevt/Logs/System.evtx
+/Windows/System32/winevt/Logs/Application.evtx
+/Windows/System32/winevt/Logs/Setup.evtx
+```
+
+### diagnostic-eventlogs-client-windowsupdate
+```
+/Windows/System32/winevt/Logs/Microsoft-Windows-WindowsUpdateClient%4Operational.evtx
+/Windows/System32/winevt/Logs/Microsoft-Windows-Servicing%4Admin.evtx
+/Windows/System32/winevt/Logs/Microsoft-Windows-WUSA%4Operational.evtx
+```
+
+### diagnostic-eventlogs-do-windowsupdate
+```
+/Windows/System32/winevt/Logs/Microsoft-Windows-DeliveryOptimization%4Operational.evtx
+/Windows/System32/winevt/Logs/Microsoft-Windows-Bits-Client%4Operational.evtx
+```
+
+### diagnostic-eventlogs-setup-osupgrade
+```
+/Windows/System32/winevt/Logs/Microsoft-Windows-Setup%4Operational.evtx
+/Windows/System32/winevt/Logs/Microsoft-Windows-Upgrade-Diagnostics%4Operational.evtx
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Windows Update failures | `eventlogs-general-common` + `eventlogs-client-windowsupdate` |
+| Download issues | `eventlogs-do-windowsupdate` |
+| OS Upgrade failures | `eventlogs-setup-osupgrade` + `eventlogs-general-common` |
+| Boot/driver issues | `eventlogs-kernel-common` |
+| Scheduled task issues | `eventlogs-taskscheduler-common` |
+| Policy issues | `eventlogs-grouppolicy-common` |

--- a/docs/manifests/windows/diagnostic-logs.md
+++ b/docs/manifests/windows/diagnostic-logs.md
@@ -1,0 +1,72 @@
+# Windows Update Logs Diagnostic Manifests
+
+Modular manifests for Windows Update and Setup log files.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-logs-client-windowsupdate` | WindowsUpdate.log, ETL | 10-100 MB | None |
+| `diagnostic-logs-sih-windowsupdate` | SIH service logs | 5-20 MB | None |
+| `diagnostic-logs-dpx-windowsupdate` | DPX setup logs | 1-10 MB | None |
+| `diagnostic-logs-setupapi-windowsupdate` | SetupAPI logs | 10-50 MB | None |
+| `diagnostic-logs-mosetup-osupgrade` | MoSetup/UpdateAgent | 5-30 MB | None |
+
+## File Locations
+
+### diagnostic-logs-client-windowsupdate
+```
+/Windows/WindowsUpdate.log
+/Windows/Logs/WindowsUpdate/*.log
+/Windows/Logs/WindowsUpdate/*.etl
+```
+
+### diagnostic-logs-sih-windowsupdate
+```
+/Windows/Logs/SIH/SIH*.log
+/Windows/Logs/SIH/SIH*.etl
+```
+
+### diagnostic-logs-dpx-windowsupdate
+```
+/Windows/Logs/DPX/setupact.log
+/Windows/Logs/DPX/setuperr.log
+```
+
+### diagnostic-logs-setupapi-windowsupdate
+```
+/Windows/INF/setupapi.dev.log
+/Windows/INF/setupapi.app.log
+```
+
+### diagnostic-logs-mosetup-osupgrade
+```
+/Windows/Logs/mosetup/UpdateAgent.log
+/Windows/Logs/MoSetup/BlueBox.log
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Windows Update failures | `logs-client-windowsupdate` |
+| Driver update issues | `logs-setupapi-windowsupdate` |
+| Feature update issues | `logs-mosetup-osupgrade` |
+| SIH/remediation issues | `logs-sih-windowsupdate` |
+| Package extraction | `logs-dpx-windowsupdate` |
+
+## Log Descriptions
+
+| Log | Purpose |
+|-----|---------|
+| WindowsUpdate.log | Main WU client log (legacy and ETL-converted) |
+| SIH*.log | Self-Initiated Healing service logs |
+| setupapi.dev.log | Device driver installation log |
+| setupapi.app.log | Application setup log |
+| UpdateAgent.log | Feature update agent log |
+
+## Notes
+
+- WindowsUpdate.log on Windows 10+ requires ETL conversion
+- SetupAPI logs are key for driver installation issues
+- SIH is used for automated WU remediation

--- a/docs/manifests/windows/diagnostic-orchestrator.md
+++ b/docs/manifests/windows/diagnostic-orchestrator.md
@@ -1,0 +1,43 @@
+# Windows Update Orchestrator Diagnostic Manifests
+
+Modular manifests for Update Session Orchestrator (USO) and health tools.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-orchestrator-uso-windowsupdate` | USO UpdateStore, logs | 10-100 MB | None |
+| `diagnostic-orchestrator-healthtools-windowsupdate` | Update Health Tools | 5-30 MB | None |
+
+## File Locations
+
+### diagnostic-orchestrator-uso-windowsupdate
+```
+/ProgramData/USOPrivate/UpdateStore/*.xml
+/ProgramData/USOShared/Logs/*.log
+/ProgramData/USOShared/Logs/*.etl
+ll,/ProgramData/USOPrivate
+ll,/ProgramData/USOShared
+```
+
+### diagnostic-orchestrator-healthtools-windowsupdate
+```
+/ProgramData/Microsoft/Windows/UpdateHealthTools/*.log
+/ProgramData/Microsoft/Windows/UpdateHealthTools/*.etl
+ll,/ProgramData/Microsoft/Windows/UpdateHealthTools
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Updates not scanning | `orchestrator-uso-windowsupdate` |
+| Updates stuck pending | `orchestrator-uso-windowsupdate` |
+| WU service issues | `orchestrator-uso-windowsupdate` + `orchestrator-healthtools-windowsupdate` |
+| Update Health alerts | `orchestrator-healthtools-windowsupdate` |
+
+## Notes
+
+- USO (Update Session Orchestrator) replaced the legacy WU service in Windows 10+
+- UpdateStore contains pending update state
+- Update Health Tools are used by Microsoft to diagnose WU issues remotely

--- a/docs/manifests/windows/diagnostic-osupgrade.md
+++ b/docs/manifests/windows/diagnostic-osupgrade.md
@@ -1,0 +1,57 @@
+# Windows OS Upgrade Additional Diagnostic Manifests
+
+Modular manifests for OS Upgrade compatibility and cleanup.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-compat-appraiser-osupgrade` | Compatibility Appraiser | 5-50 MB | None |
+| `diagnostic-previousos-osupgrade` | Windows.old folder | 10-50 MB | Low |
+| `diagnostic-cleanup-osupgrade` | Disk Cleanup logs | 1-10 MB | None |
+
+## File Locations
+
+### diagnostic-compat-appraiser-osupgrade
+```
+/Windows/appcompat/Appraiser*.xml
+/Windows/appcompat/Appraiser*.cab
+ll,/Windows/appcompat/Programs
+```
+
+### diagnostic-previousos-osupgrade
+```
+ll,/Windows.old
+/Windows.old/Windows/Panther/setupact.log
+/Windows.old/Windows/Panther/setuperr.log
+```
+
+### diagnostic-cleanup-osupgrade
+```
+/Windows/Logs/DiskCleanup/DiskCleanup.log
+ll,/Windows/Logs/DiskCleanup
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Compatibility blocks | `compat-appraiser-osupgrade` |
+| Upgrade safeguard holds | `compat-appraiser-osupgrade` |
+| Previous OS recovery | `previousos-osupgrade` |
+| Disk space issues | `cleanup-osupgrade` |
+| Rollback investigation | `previousos-osupgrade` |
+
+## Component Descriptions
+
+| Component | Purpose |
+|-----------|---------|
+| Appraiser | Evaluates system compatibility before feature updates |
+| Windows.old | Contains previous Windows installation for rollback |
+| Disk Cleanup | Handles removal of update cleanup files |
+
+## Notes
+
+- Appraiser data identifies compatibility blockers for feature updates
+- Windows.old exists for 10 days after upgrade (by default)
+- Cleanup logs show what was removed during update cleanup

--- a/docs/manifests/windows/diagnostic-provisioning.md
+++ b/docs/manifests/windows/diagnostic-provisioning.md
@@ -1,0 +1,64 @@
+# Windows Provisioning Diagnostic Manifests
+
+Modular manifests for Windows provisioning and setup diagnostics.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-provisioning-panther-osupgrade` | Panther setup logs | 10-50 MB | Low |
+| `diagnostic-provisioning-sysprep-osupgrade` | Sysprep files and logs | 5-30 MB | Low |
+| `diagnostic-provisioning-state-osupgrade` | Setup State.ini | 1-5 MB | None |
+| `diagnostic-provisioning-firstboot-osupgrade` | First logon commands | 1-10 MB | None |
+
+## File Locations
+
+### diagnostic-provisioning-panther-osupgrade
+```
+/Windows/Panther/setupact.log
+/Windows/Panther/setuperr.log
+/Windows/Panther/UnattendGC/setupact.log
+/Windows/Panther/UnattendGC/setuperr.log
+/Windows/Panther/cbs_unattend.log
+/Windows/Panther/DDACLSys.log
+/Windows/Panther/UnattendedJoin/UnattendedJoinDCLocator.etl
+/Windows/Panther/miglog.xml
+```
+
+### diagnostic-provisioning-sysprep-osupgrade
+```
+/Windows/System32/Sysprep/Panther/setupact.log
+/Windows/System32/Sysprep/Panther/setuperr.log
+/Windows/System32/Sysprep/Panther/IE/setupact.log
+/Windows/System32/Sysprep/Sysprep_succeeded.tag
+/Windows/System32/Sysprep/Unattend.xml
+ll,/Windows/System32/Sysprep
+```
+
+### diagnostic-provisioning-state-osupgrade
+```
+/Windows/Setup/State/State.ini
+ll,/Windows/Setup/State
+```
+
+### diagnostic-provisioning-firstboot-osupgrade
+```
+/Windows/Panther/FirstLogonCommands.log
+/Windows/Panther/Specialize.log
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| VM provisioning failures | `provisioning-panther-osupgrade` + `provisioning-sysprep-osupgrade` |
+| Sysprep failures | `provisioning-sysprep-osupgrade` |
+| Setup stuck | `provisioning-state-osupgrade` + `provisioning-panther-osupgrade` |
+| First boot issues | `provisioning-firstboot-osupgrade` |
+| Azure VM generalization | `provisioning-sysprep-osupgrade` |
+
+## Key Error Patterns
+
+- setupact.log: Look for `Error`, `Warning`, `OOBE`
+- setuperr.log: All entries are errors
+- State.ini: Check `IMAGE_STATE` value

--- a/docs/manifests/windows/diagnostic-recovery.md
+++ b/docs/manifests/windows/diagnostic-recovery.md
@@ -1,0 +1,56 @@
+# Windows Recovery Diagnostic Manifests
+
+Modular manifests for Windows recovery and error reporting.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-recovery-startuprepair-osupgrade` | Startup Repair logs | 1-10 MB | None |
+| `diagnostic-recovery-wer-osupgrade` | Windows Error Reporting | 5-30 MB | Low |
+| `diagnostic-recovery-postsetup-osupgrade` | Post-setup action logs | 1-10 MB | None |
+
+## File Locations
+
+### diagnostic-recovery-startuprepair-osupgrade
+```
+/Windows/System32/LogFiles/Srt/SrtTrail.txt
+/Windows/System32/LogFiles/Srt/srt-ui-*.txt
+ll,/Windows/System32/LogFiles/Srt
+```
+
+### diagnostic-recovery-wer-osupgrade
+```
+ll,/ProgramData/Microsoft/Windows/WER/ReportQueue
+/ProgramData/Microsoft/Windows/WER/ReportQueue/*/Report.wer
+```
+
+### diagnostic-recovery-postsetup-osupgrade
+```
+/Windows/Logs/mosetup/UpdateAgent.log
+/Windows/Logs/MoSetup/BlueBox.log
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Boot loop after update | `recovery-startuprepair-osupgrade` |
+| BSOD after update | `recovery-wer-osupgrade` |
+| Upgrade completed but issues | `recovery-postsetup-osupgrade` |
+| Automatic repair triggered | `recovery-startuprepair-osupgrade` |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `SrtTrail.txt` | Startup Repair diagnostic trail |
+| `Report.wer` | Windows Error Report details |
+| `UpdateAgent.log` | Post-upgrade setup actions |
+| `BlueBox.log` | Feature update completion tasks |
+
+## Notes
+
+- SrtTrail.txt is created when Startup Repair runs
+- WER reports contain crash details and may identify failing components
+- Post-setup logs show actions taken after feature update completes

--- a/docs/manifests/windows/diagnostic-registry.md
+++ b/docs/manifests/windows/diagnostic-registry.md
@@ -1,0 +1,58 @@
+# Windows Registry Diagnostic Manifests
+
+Modular manifests for collecting Windows Registry hives.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-registry-bcd-common` | Boot Configuration Data | 1-5 MB | None |
+| `diagnostic-registry-system-common` | SYSTEM hive | 20-80 MB | Low |
+| `diagnostic-registry-software-common` | SOFTWARE hive | 50-200 MB | Medium |
+| `diagnostic-registry-components-windowsupdate` | COMPONENTS hive (CBS) | 50-300 MB | None |
+
+## File Locations
+
+### diagnostic-registry-bcd-common
+```
+/Boot/BCD
+```
+
+### diagnostic-registry-system-common
+```
+/Windows/System32/config/SYSTEM
+```
+
+### diagnostic-registry-software-common
+```
+/Windows/System32/config/SOFTWARE
+```
+
+### diagnostic-registry-components-windowsupdate
+```
+/Windows/System32/config/COMPONENTS
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Boot failures | `registry-bcd-common` + `registry-system-common` |
+| Service issues | `registry-system-common` |
+| Windows Update | `registry-components-windowsupdate` + `registry-software-common` |
+| CBS corruption | `registry-components-windowsupdate` |
+| Driver issues | `registry-system-common` |
+
+## Size Warnings
+
+| Manifest | Warning |
+|----------|---------|
+| `diagnostic-registry-software-common` | Can be 50-200 MB |
+| `diagnostic-registry-components-windowsupdate` | Can be 50-300 MB on systems with many updates |
+
+## Notes
+
+- All registry hives use `noscan` to prevent content scanning
+- COMPONENTS hive grows significantly with installed updates
+- SOFTWARE contains machine policies and application settings
+- SYSTEM contains service configurations and driver settings

--- a/docs/manifests/windows/diagnostic-servicing.md
+++ b/docs/manifests/windows/diagnostic-servicing.md
@@ -1,0 +1,68 @@
+# Windows Servicing Diagnostic Manifests
+
+Modular manifests for Component-Based Servicing (CBS) diagnostics.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-servicing-cbs-windowsupdate` | CBS logs and cabs | 50-300 MB | None |
+| `diagnostic-servicing-dism-windowsupdate` | DISM operation logs | 5-30 MB | None |
+| `diagnostic-servicing-sessions-windowsupdate` | Servicing Sessions.xml | 1-10 MB | None |
+| `diagnostic-servicing-sfc-windowsupdate` | System File Checker logs | 1-10 MB | None |
+| `diagnostic-servicing-waasmedic-windowsupdate` | WaaS Medic service logs | 5-20 MB | None |
+
+## File Locations
+
+### diagnostic-servicing-cbs-windowsupdate
+```
+/Windows/Logs/CBS/CBS.log
+/Windows/Logs/CBS/CbsPersist*.log
+/Windows/Logs/CBS/CbsPersist*.cab
+```
+
+### diagnostic-servicing-dism-windowsupdate
+```
+/Windows/Logs/DISM/dism.log
+/Windows/Logs/DISM/dism_*.log
+```
+
+### diagnostic-servicing-sessions-windowsupdate
+```
+/Windows/servicing/Sessions.xml
+/Windows/servicing/Sessions/Sessions.xml
+ll,/Windows/servicing/Sessions
+```
+
+### diagnostic-servicing-sfc-windowsupdate
+```
+/Windows/Logs/CBS/sfc*.log
+```
+
+### diagnostic-servicing-waasmedic-windowsupdate
+```
+/Windows/Logs/waasmedic/waasmedic.log
+/Windows/Logs/waasmedic/WaaSMedic*.etl
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Update installation failures | `servicing-cbs-windowsupdate` + `servicing-dism-windowsupdate` |
+| CBS corruption | `servicing-cbs-windowsupdate` + `servicing-sessions-windowsupdate` |
+| DISM errors | `servicing-dism-windowsupdate` |
+| SFC failures | `servicing-sfc-windowsupdate` + `servicing-cbs-windowsupdate` |
+| WU not working | `servicing-waasmedic-windowsupdate` |
+
+## Size Warnings
+
+| Manifest | Warning |
+|----------|---------|
+| `diagnostic-servicing-cbs-windowsupdate` | CbsPersist cabs can be 10-100 MB each |
+
+## Key Error Patterns
+
+- CBS.log: `Error`, `HRESULT`, `STATUS_`
+- DISM.log: `Error`, `Failed`
+- SFC: `Cannot repair`, `Corrupt`

--- a/docs/manifests/windows/diagnostic-softwaredistribution.md
+++ b/docs/manifests/windows/diagnostic-softwaredistribution.md
@@ -1,0 +1,66 @@
+# Windows Software Distribution Diagnostic Manifests
+
+Modular manifests for Windows Update download cache and database.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-softwaredistribution-reporting-windowsupdate` | ReportingEvents.log | 1-10 MB | None |
+| `diagnostic-softwaredistribution-do-windowsupdate` | Delivery Optimization logs | 5-50 MB | None |
+| `diagnostic-softwaredistribution-plugins-windowsupdate` | WU Plugins directory | 1-5 MB | None |
+| `diagnostic-softwaredistribution-download-windowsupdate` | Download metadata, SLS | 5-30 MB | None |
+| `diagnostic-softwaredistribution-datastore-windowsupdate` | DataStore.edb database | 50-500 MB | None |
+
+## File Locations
+
+### diagnostic-softwaredistribution-reporting-windowsupdate
+```
+/Windows/SoftwareDistribution/ReportingEvents.log
+```
+
+### diagnostic-softwaredistribution-do-windowsupdate
+```
+/Windows/SoftwareDistribution/DeliveryOptimization*.log
+/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Logs/*.log
+/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Logs/*.etl
+```
+
+### diagnostic-softwaredistribution-plugins-windowsupdate
+```
+ll,/Windows/SoftwareDistribution/Plugins
+```
+
+### diagnostic-softwaredistribution-download-windowsupdate
+```
+ll,/Windows/SoftwareDistribution/Download
+/Windows/SoftwareDistribution/Download/*.log
+/Windows/SoftwareDistribution/SLS/*.log
+```
+
+### diagnostic-softwaredistribution-datastore-windowsupdate
+```
+/Windows/SoftwareDistribution/DataStore/DataStore.edb (noscan)
+/Windows/SoftwareDistribution/DataStore/Logs/*.log
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Update history | `softwaredistribution-reporting-windowsupdate` |
+| Download failures | `softwaredistribution-do-windowsupdate` + `softwaredistribution-download-windowsupdate` |
+| WU database corruption | `softwaredistribution-datastore-windowsupdate` |
+| P2P download issues | `softwaredistribution-do-windowsupdate` |
+
+## Size Warnings
+
+| Manifest | Warning |
+|----------|---------|
+| `diagnostic-softwaredistribution-datastore-windowsupdate` | DataStore.edb can be 50-500 MB |
+
+## Notes
+
+- ReportingEvents.log contains history of all update operations
+- DataStore.edb is the Windows Update database
+- Delivery Optimization handles P2P and CDN downloads

--- a/docs/manifests/windows/diagnostic-staging.md
+++ b/docs/manifests/windows/diagnostic-staging.md
@@ -1,0 +1,60 @@
+# Windows OS Upgrade Staging Diagnostic Manifests
+
+Modular manifests for Windows Feature Update staging folders.
+
+## Available Manifests
+
+| Manifest | Description | Size Est. | PII |
+|----------|-------------|-----------|-----|
+| `diagnostic-staging-bt-osupgrade` | $Windows.~BT staging | 10-100 MB | None |
+| `diagnostic-staging-ws-osupgrade` | $Windows.~WS rollback | 10-100 MB | None |
+| `diagnostic-staging-safeos-osupgrade` | SafeOS DU phase | 5-30 MB | None |
+
+## File Locations
+
+### diagnostic-staging-bt-osupgrade
+```
+ll,/$Windows.~BT
+/$Windows.~BT/Sources/Panther/setupact.log
+/$Windows.~BT/Sources/Panther/setuperr.log
+/$Windows.~BT/Sources/Panther/miglog.xml
+/$Windows.~BT/Sources/Panther/cbs_unattend.log
+```
+
+### diagnostic-staging-ws-osupgrade
+```
+ll,/$Windows.~WS
+/$Windows.~WS/Sources/Panther/setupact.log
+/$Windows.~WS/Sources/Panther/setuperr.log
+```
+
+### diagnostic-staging-safeos-osupgrade
+```
+ll,/$Windows.~BT/Sources/SafeOS/SafeOS.Mount
+/$Windows.~BT/Sources/SafeOS/setupact.log
+/$Windows.~BT/Sources/SafeOS/setuperr.log
+```
+
+## Use Cases
+
+| Issue Type | Recommended Manifests |
+|------------|----------------------|
+| Feature update download phase | `staging-bt-osupgrade` |
+| Feature update installation | `staging-bt-osupgrade` + `staging-safeos-osupgrade` |
+| Rollback occurred | `staging-ws-osupgrade` + `staging-bt-osupgrade` |
+| SafeOS boot failures | `staging-safeos-osupgrade` |
+
+## Folder Descriptions
+
+| Folder | Purpose |
+|--------|---------|
+| `$Windows.~BT` | Feature update staging - downloaded content and setup logs |
+| `$Windows.~WS` | Windows Setup rollback data |
+| `SafeOS` | WinRE-based phase for applying updates |
+
+## Notes
+
+- These folders exist only during/after feature updates
+- `$Windows.~BT` is created during download phase
+- `$Windows.~WS` contains rollback information if upgrade fails
+- SafeOS is used for the "Installing updates" phase at reboot

--- a/docs/manifests/windows/diagnostic-windowsupdate.md
+++ b/docs/manifests/windows/diagnostic-windowsupdate.md
@@ -1,0 +1,250 @@
+# Windows Update and OS Upgrade Diagnostic Manifests - Modular Reference
+
+This document provides an overview of modular Windows Update and OS Upgrade diagnostic manifests. For detailed documentation on each area, see the specific docs linked below.
+
+## Documentation by Area
+
+| Area | Document | Description |
+|------|----------|-------------|
+| Event Logs | [diagnostic-eventlogs.md](diagnostic-eventlogs.md) | System, WU, DO, Setup event logs |
+| Registry | [diagnostic-registry.md](diagnostic-registry.md) | BCD, SYSTEM, SOFTWARE, COMPONENTS |
+| Servicing | [diagnostic-servicing.md](diagnostic-servicing.md) | CBS, DISM, SFC, WaaS Medic |
+| Software Distribution | [diagnostic-softwaredistribution.md](diagnostic-softwaredistribution.md) | Download cache, DataStore, DO |
+| Orchestrator | [diagnostic-orchestrator.md](diagnostic-orchestrator.md) | USO, Update Health Tools |
+| Provisioning | [diagnostic-provisioning.md](diagnostic-provisioning.md) | Panther, Sysprep, Setup State |
+| Staging | [diagnostic-staging.md](diagnostic-staging.md) | $Windows.~BT, ~WS, SafeOS |
+| Recovery | [diagnostic-recovery.md](diagnostic-recovery.md) | Startup Repair, WER, Post-Setup |
+| Logs | [diagnostic-logs.md](diagnostic-logs.md) | WindowsUpdate.log, SetupAPI, SIH |
+| OS Upgrade | [diagnostic-osupgrade.md](diagnostic-osupgrade.md) | Appraiser, Windows.old, Cleanup |
+
+## Naming Convention
+
+**Format:** `diagnostic-<category>-<subcategory>-<windowsupdate|osupgrade|common>`
+
+- Category-first enables grouping by data type
+- `-windowsupdate` suffix = Windows Update specific
+- `-osupgrade` suffix = Feature Update / OS Upgrade specific
+- `-common` suffix = shared across both scenarios
+
+---
+
+## Quick Reference - All Manifests
+
+### Event Logs
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-eventlogs-general-common` | System, Application, Setup logs | 25-150 MB |
+| `diagnostic-eventlogs-client-windowsupdate` | Windows Update client event logs | 5-50 MB |
+| `diagnostic-eventlogs-do-windowsupdate` | Delivery Optimization, BITS logs | 5-30 MB |
+| `diagnostic-eventlogs-setup-osupgrade` | OS Setup and Upgrade Diagnostics logs | 5-50 MB |
+| `diagnostic-eventlogs-taskscheduler-common` | Task Scheduler operational logs | 5-30 MB |
+| `diagnostic-eventlogs-kernel-common` | Kernel PnP, Kernel Power logs | 5-30 MB |
+| `diagnostic-eventlogs-security-common` | CAPI2, Licensing logs | 5-30 MB |
+| `diagnostic-eventlogs-grouppolicy-common` | Group Policy operational logs | 5-20 MB |
+
+### Registry Hives
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-registry-bcd-common` | Boot Configuration Data | 1-5 MB |
+| `diagnostic-registry-system-common` | SYSTEM hive | 20-80 MB |
+| `diagnostic-registry-software-common` | SOFTWARE hive | 50-200 MB |
+| `diagnostic-registry-components-windowsupdate` | COMPONENTS hive (CBS state) | 50-300 MB |
+
+### Component-Based Servicing (Windows Update)
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-servicing-cbs-windowsupdate` | CBS logs and cabs | 50-300 MB |
+| `diagnostic-servicing-dism-windowsupdate` | DISM logs | 5-30 MB |
+| `diagnostic-servicing-sessions-windowsupdate` | Servicing Sessions.xml | 1-10 MB |
+| `diagnostic-servicing-sfc-windowsupdate` | SFC logs | 1-10 MB |
+| `diagnostic-servicing-waasmedic-windowsupdate` | WaaS Medic service logs | 5-20 MB |
+
+### Software Distribution (Windows Update)
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-softwaredistribution-reporting-windowsupdate` | ReportingEvents.log | 1-10 MB |
+| `diagnostic-softwaredistribution-do-windowsupdate` | Delivery Optimization logs | 5-50 MB |
+| `diagnostic-softwaredistribution-plugins-windowsupdate` | WU Plugins directory | 1-5 MB |
+| `diagnostic-softwaredistribution-download-windowsupdate` | Download metadata, SLS logs | 5-30 MB |
+| `diagnostic-softwaredistribution-datastore-windowsupdate` | DataStore.edb database | 50-500 MB |
+
+### Windows Update Logs
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-logs-client-windowsupdate` | WindowsUpdate.log, ETL traces | 10-100 MB |
+| `diagnostic-logs-sih-windowsupdate` | SIH service logs | 5-20 MB |
+| `diagnostic-logs-dpx-windowsupdate` | DPX setup logs | 1-10 MB |
+| `diagnostic-logs-setupapi-windowsupdate` | SetupAPI device/app logs | 10-50 MB |
+
+### Update Orchestrator (Windows Update)
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-orchestrator-uso-windowsupdate` | USO UpdateStore, logs | 10-100 MB |
+| `diagnostic-orchestrator-healthtools-windowsupdate` | Update Health Tools logs | 5-30 MB |
+
+### Provisioning (OS Upgrade)
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-provisioning-panther-osupgrade` | Panther setup logs | 10-50 MB |
+| `diagnostic-provisioning-sysprep-osupgrade` | Sysprep files and logs | 5-30 MB |
+| `diagnostic-provisioning-state-osupgrade` | Setup State.ini | 1-5 MB |
+| `diagnostic-provisioning-firstboot-osupgrade` | First logon commands log | 1-10 MB |
+
+### OS Upgrade Staging
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-staging-bt-osupgrade` | $Windows.~BT staging folder | 10-100 MB |
+| `diagnostic-staging-ws-osupgrade` | $Windows.~WS rollback folder | 10-100 MB |
+| `diagnostic-staging-safeos-osupgrade` | SafeOS DU phase logs | 5-30 MB |
+
+### OS Upgrade - Additional
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-compat-appraiser-osupgrade` | Compatibility Appraiser data | 5-50 MB |
+| `diagnostic-logs-mosetup-osupgrade` | MoSetup/UpdateAgent logs | 5-30 MB |
+| `diagnostic-previousos-osupgrade` | Windows.old folder logs | 10-50 MB |
+| `diagnostic-cleanup-osupgrade` | Disk Cleanup logs | 1-10 MB |
+
+### Recovery (OS Upgrade)
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-recovery-startuprepair-osupgrade` | SRT startup repair logs | 1-10 MB |
+| `diagnostic-recovery-wer-osupgrade` | Windows Error Reporting queue | 5-30 MB |
+| `diagnostic-recovery-postsetup-osupgrade` | Post-setup action logs | 1-10 MB |
+
+### Azure Extensions
+| Manifest | Description | Size Est. |
+|----------|-------------|-----------|
+| `diagnostic-extensions-updatemanager` | Azure Update Manager extension | 5-100 MB |
+
+## Monolithic Manifest
+
+The original `windowsupdate` manifest remains available and includes all of the above.
+
+## Issue Type Selection
+
+### Windows Update Failure - General
+```
+diagnostic-eventlogs-general-common
+diagnostic-eventlogs-client-windowsupdate
+diagnostic-servicing-cbs-windowsupdate
+diagnostic-logs-client-windowsupdate
+```
+
+### Windows Update Failure - Download Issues
+```
+diagnostic-softwaredistribution-reporting-windowsupdate
+diagnostic-softwaredistribution-do-windowsupdate
+diagnostic-softwaredistribution-datastore-windowsupdate
+diagnostic-orchestrator-uso-windowsupdate
+diagnostic-eventlogs-do-windowsupdate
+```
+
+### Windows Update Failure - Installation Issues
+```
+diagnostic-servicing-cbs-windowsupdate
+diagnostic-servicing-dism-windowsupdate
+diagnostic-logs-client-windowsupdate
+diagnostic-eventlogs-client-windowsupdate
+diagnostic-registry-components-windowsupdate
+```
+
+### Azure Update Manager Issues
+```
+diagnostic-extensions-updatemanager
+diagnostic-eventlogs-client-windowsupdate
+diagnostic-servicing-cbs-windowsupdate
+```
+
+### OS Upgrade Failure - Pre-Upgrade
+```
+diagnostic-compat-appraiser-osupgrade
+diagnostic-provisioning-state-osupgrade
+diagnostic-eventlogs-setup-osupgrade
+```
+
+### OS Upgrade Failure - During Upgrade
+```
+diagnostic-staging-bt-osupgrade
+diagnostic-staging-safeos-osupgrade
+diagnostic-servicing-cbs-windowsupdate
+diagnostic-eventlogs-setup-osupgrade
+```
+
+### OS Upgrade Failure - Rollback
+```
+diagnostic-staging-ws-osupgrade
+diagnostic-previousos-osupgrade
+diagnostic-recovery-postsetup-osupgrade
+diagnostic-eventlogs-setup-osupgrade
+```
+
+### Boot Failure After Update
+```
+diagnostic-recovery-startuprepair-osupgrade
+diagnostic-recovery-wer-osupgrade
+diagnostic-registry-bcd-common
+diagnostic-eventlogs-kernel-common
+```
+
+### VM Provisioning Issues
+```
+diagnostic-provisioning-panther-osupgrade
+diagnostic-provisioning-sysprep-osupgrade
+diagnostic-provisioning-firstboot-osupgrade
+diagnostic-eventlogs-general-common
+diagnostic-registry-system-common
+```
+
+## Manifest Details
+
+### diagnostic-registry-*-common
+Registry hives containing system configuration:
+- `/Boot/BCD` - Boot Configuration Data (diagnostic-registry-bcd-common)
+- `/Windows/System32/config/SYSTEM` - Service configurations (diagnostic-registry-system-common)
+- `/Windows/System32/config/SOFTWARE` - WU policies, CBS state (diagnostic-registry-software-common)
+
+### diagnostic-registry-components-windowsupdate
+CBS-specific registry hive:
+- `/Windows/System32/config/COMPONENTS` - Component servicing state
+
+### diagnostic-servicing-*-windowsupdate
+Component-Based Servicing - primary diagnostic source:
+- `diagnostic-servicing-cbs-windowsupdate` - CBS logs, CBS.log, CbsPersist cabs
+- `diagnostic-servicing-dism-windowsupdate` - DISM.log
+- `diagnostic-servicing-sessions-windowsupdate` - Sessions.xml
+- `diagnostic-servicing-sfc-windowsupdate` - SFC logs
+- `diagnostic-servicing-waasmedic-windowsupdate` - WaaS Medic logs
+
+### diagnostic-softwaredistribution-*-windowsupdate
+Windows Update download cache and database:
+- `diagnostic-softwaredistribution-reporting-windowsupdate` - ReportingEvents.log
+- `diagnostic-softwaredistribution-do-windowsupdate` - Delivery Optimization logs
+- `diagnostic-softwaredistribution-datastore-windowsupdate` - DataStore.edb (50-500 MB)
+- `diagnostic-softwaredistribution-download-windowsupdate` - Download metadata
+- `diagnostic-softwaredistribution-plugins-windowsupdate` - WU plugins
+
+### diagnostic-staging-*-osupgrade
+Feature update staging folder contents:
+- `diagnostic-staging-bt-osupgrade` - $Windows.~BT/Sources/Panther/*
+- `diagnostic-staging-ws-osupgrade` - $Windows.~WS rollback logs
+- `diagnostic-staging-safeos-osupgrade` - SafeOS phase logs
+
+## Size Warnings
+
+| Manifest | Warning |
+|----------|---------|
+| `diagnostic-registry-software-common` | SOFTWARE hive can be 50-200 MB |
+| `diagnostic-registry-components-windowsupdate` | COMPONENTS hive can be 50-300 MB |
+| `diagnostic-servicing-cbs-windowsupdate` | CBS cab files can be 10-100 MB each |
+| `diagnostic-softwaredistribution-datastore-windowsupdate` | DataStore.edb can be 50-500 MB |
+
+## Total Size Estimates
+
+| Scenario | Manifests | Total Size |
+|----------|-----------|------------|
+| Minimal WU triage | eventlogs + cbs | 75-450 MB |
+| Full WU diagnostics | All *-windowsupdate manifests | 200 MB - 1.5 GB |
+| OS Upgrade diagnostics | All *-osupgrade manifests | 50-450 MB |
+| Full diagnostics | All manifests | 350 MB - 2.5 GB |
+

--- a/docs/manifests/windows/windowsupdate.md
+++ b/docs/manifests/windows/windowsupdate.md
@@ -1,0 +1,465 @@
+# Windows Update Manifest Documentation
+
+This document describes the `windowsupdate` manifest used for diagnosing Windows Update, OS upgrade, and OS reinstall failures on Azure VMs.
+
+---
+
+## Summary
+
+| Category | Sections | Estimated Total Size |
+|----------|----------|---------------------|
+| **Windows Update (Patches)** | 10 sections | 100MB - 1GB |
+| **OS Upgrade (Feature Updates)** | 8 sections | 50MB - 500MB |
+| **Shared/Recovery** | 4 sections | 10MB - 100MB |
+| **Total Estimated** | 22 sections | **200MB - 1.5GB** |
+
+---
+
+## Windows Update Sections
+
+### Registry Hives
+
+| File | Typical Size | Purpose |
+|------|--------------|---------|
+| `/Boot/BCD` | 256KB - 1MB | Boot Configuration Data - boot entries affected by updates |
+| `/Windows/System32/config/SOFTWARE` | 50MB - 200MB | Windows Update policies, CBS state, installed updates registry |
+| `/Windows/System32/config/SYSTEM` | 10MB - 50MB | Service configurations (wuauserv, BITS, TrustedInstaller) |
+
+**Why Important:** Registry contains Windows Update agent configuration, pending update state, component store health, and service configurations critical for troubleshooting.
+
+**Estimated Files:** 3 files | **Estimated Size:** 60MB - 250MB
+
+---
+
+### Event Logs (General)
+
+| File | Typical Size | Purpose |
+|------|--------------|---------|
+| `System.evtx` | 20MB - 128MB | Windows Update service events, restart events, driver installs |
+| `Application.evtx` | 20MB - 128MB | Application errors during/after updates, MSI events |
+| `Setup.evtx` | 1MB - 20MB | OS setup/installation events during upgrades |
+
+**Why Important:** Primary source for error codes, timestamps, and event sequences during update failures.
+
+**Estimated Files:** 3 files | **Estimated Size:** 40MB - 275MB
+
+---
+
+### Provisioning
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/Setup/State/State.ini` | 1 | <1KB | Current setup state |
+| `/Windows/Panther/*.xml` | 3-4 | 1-10KB each | Azure VM provisioning config |
+| `/Windows/Panther/*.log` | 2-3 | 1-50MB each | Setup action logs |
+| `/Windows/Panther/*.etl` | 1 | 5-50MB | Setup ETL traces |
+| `/Windows/Panther/*/setupact.log` | 2-3 | 1-20MB each | Unattend and cleanup logs |
+| `/Windows/System32/Sysprep/**/*` | 6-8 | 1-10MB each | Sysprep action files and logs |
+
+**Why Important:** Tracks initial OS setup and Sysprep state - helps identify if provisioning issues cause update failures.
+
+**Estimated Files:** 15-20 files | **Estimated Size:** 20MB - 150MB
+
+---
+
+### Windows Update - CBS and Servicing
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/Logs/CBS/*.log` | 5-20 | 5-50MB each | Component-Based Servicing logs (primary WU diagnostics) |
+| `/Windows/Logs/CBS/*.cab` | 3-10 | 10-100MB each | CBS diagnostic cab files (compressed logs) |
+| `/Windows/Logs/DISM/*.log` | 1-3 | 1-20MB each | DISM operations log |
+| `/Windows/WinSxS/pending.xml` | 1 | 1KB - 5MB | Pending servicing operations |
+| `/Windows/WinSxS/poqexec.log` | 1 | 1-10MB | Post-reboot queue execution |
+| `/Windows/servicing/sessions/*` | 2-10 | 1-50MB total | Servicing session history |
+
+**Why Important:** CBS logs are the **primary diagnostic source** for Windows Update failures. Contains detailed error codes, package states, and installation sequences.
+
+**⚠️ Size Warning:** CBS cab files can be very large (10-100MB each). Consider requesting tool enhancement for `latest:N` syntax.
+
+**Estimated Files:** 15-40 files | **Estimated Size:** 50MB - 500MB
+
+---
+
+### Windows Update - WaaS Medic
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/Logs/waasmedic/*.etl` | 1-5 | 1-20MB each | Windows Update auto-repair diagnostics |
+
+**Why Important:** Shows if Windows tried to self-heal broken WU components and what it found/fixed.
+
+**Estimated Files:** 1-5 files | **Estimated Size:** 1MB - 100MB
+
+---
+
+### Windows Update - Setup API
+
+| File | Typical Size | Purpose |
+|------|--------------|---------|
+| `/Windows/INF/setupapi.dev.log` | 5MB - 50MB | Device/driver installation during updates |
+
+**Why Important:** Driver installation failures during updates cause many issues - this log captures all driver operations.
+
+**Estimated Files:** 1 file | **Estimated Size:** 5MB - 50MB
+
+---
+
+### Windows Update - Logs and ETL
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/windowsupdate*.log` | 1-2 | 1-10MB | Legacy WU log (pre-1709) |
+| `/Windows/Logs/WindowsUpdate/*.etl` | 2-10 | 5-50MB each | Modern WU ETL traces |
+| `/Windows/Logs/SIH/*.etl` | 1-5 | 1-10MB each | Server-Initiated Healing (MS-pushed fixes) |
+| `/Windows/Logs/dpx/*.log` | 1-3 | 1-5MB each | Package expansion logs |
+| `/WindowsUpdateVerbose.etl` | 0-1 | 10-100MB | Verbose WU trace (if enabled) |
+
+**Why Important:** ETL traces contain detailed Windows Update client operations not visible in event logs.
+
+**Estimated Files:** 5-20 files | **Estimated Size:** 20MB - 200MB
+
+---
+
+### Windows Update - SoftwareDistribution
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `ReportingEvents.log` | 1 | 1-10MB | Update reporting history |
+| `DeliveryOptimization/SavedLogs/*` | 2-10 | 1-20MB each | DO download logs |
+| `Plugins/*/*.log` | 1-3 | 1-5MB each | Token/auth plugin logs |
+| `Plugins/*/*.cache` | 1-3 | <1MB each | Plugin cache |
+| `Download/*/*/*.xml` | 0-20 | <100KB each | Download metadata |
+| `Download/*/*/*.log` | 0-10 | 1-5MB each | Download logs |
+| `datastore/DataStore.edb` | 1 | 50MB - 500MB | Windows Update database |
+
+**Why Important:** Contains the Windows Update download cache, update history database, and delivery optimization state.
+
+**⚠️ Size Warning:** DataStore.edb can be 50-500MB.
+
+**Estimated Files:** 10-50 files | **Estimated Size:** 60MB - 600MB
+
+---
+
+### Windows Update - Update Orchestrator
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/ProgramData/UsoPrivate/UpdateStore/*.xml` | 1-5 | 1-10MB each | Update orchestrator store |
+| `/ProgramData/USOShared/Logs/*.etl` | 2-10 | 5-50MB each | USO operation logs |
+| `/ProgramData/USOShared/*.etl` | 1-5 | 5-20MB each | UUP (Unified Update Platform) logs |
+
+**Why Important:** USO controls update scheduling, download orchestration, and reboot coordination.
+
+**Estimated Files:** 5-20 files | **Estimated Size:** 15MB - 200MB
+
+---
+
+### Windows Update - Update Health Tools
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/ProgramData/Microsoft/UpdateHealthTools/*.log` | 1-5 | 1-10MB each | Update health diagnostics (Win10 2004+) |
+
+**Why Important:** Microsoft's update health monitoring - shows blocked updates and remediation attempts.
+
+**Estimated Files:** 1-5 files | **Estimated Size:** 1MB - 50MB
+
+---
+
+### Windows Update - Delivery Optimization
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `DeliveryOptimization/Logs/*.etl` | 2-10 | 5-20MB each | Peer-to-peer download logs |
+| `WSLicense/tokens.dat` | 1 | <1MB | Licensing tokens |
+
+**Why Important:** Delivery Optimization issues can cause download failures - especially in restricted network environments.
+
+**Estimated Files:** 3-11 files | **Estimated Size:** 10MB - 200MB
+
+---
+
+### Windows Update - Event Logs
+
+| Event Log | Typical Size | Purpose |
+|-----------|--------------|---------|
+| `Microsoft-Windows-WindowsUpdateClient%4Operational.evtx` | 1-20MB | WU client operations |
+| `Microsoft-Windows-TaskScheduler%4Operational.evtx` | 5-50MB | Scheduled update tasks |
+| `Microsoft-Windows-Bits-Client%4Operational.evtx` | 1-20MB | BITS download operations |
+| `Microsoft-Windows-Servicing%4Admin.evtx` | 1-10MB | CBS/servicing events |
+| `Microsoft-Windows-CAPI2%4Operational.evtx` | 5-50MB | Certificate/signing issues |
+| `Microsoft-WS-Licensing%4Admin.evtx` | 1-5MB | Licensing events |
+| `Microsoft-Windows-Kernel-PnP%4Configuration.evtx` | 1-10MB | PnP device events |
+| `Microsoft-Windows-DeliveryOptimization%4Operational.evtx` | 1-20MB | DO events |
+| `Microsoft-Windows-WUSA%4Operational.evtx` | 1-5MB | Standalone installer (MSU) |
+| `Microsoft-Windows-Kernel-Power%4Operational.evtx` | 5-50MB | Unexpected reboots during updates |
+| `Microsoft-Windows-GroupPolicy%4Operational.evtx` | 5-50MB | GP affecting WU settings |
+
+**Why Important:** Comprehensive event coverage for all Windows Update subsystems.
+
+**Estimated Files:** 11 files | **Estimated Size:** 25MB - 250MB
+
+---
+
+### Azure Update Manager
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `WindowsPatchExtension/*/*.log` | 2-10 | 1-10MB each | Extension operation logs |
+| `WindowsPatchExtension/*/status/*.status` | 1-5 | <100KB each | Status files |
+| `WindowsPatchExtension/*/RuntimeSettings/*.settings` | 1-3 | <100KB each | Configuration |
+| `WindowsPatchExtension/*/config.txt` | 1 | <10KB | Config |
+| `WindowsPatchExtension/*/*.json` | 2 | <50KB each | Handler manifests |
+
+**Why Important:** Required for Azure Update Manager troubleshooting - shows extension-initiated patching operations.
+
+**Estimated Files:** 7-20 files | **Estimated Size:** 5MB - 100MB
+
+---
+
+## Recovery Sections
+
+### Startup Repair
+
+| File | Typical Size | Purpose |
+|------|--------------|---------|
+| `/Windows/System32/LogFiles/Srt/SrtTrail.txt` | 10KB - 1MB | Startup repair diagnostic trail |
+| `/Windows/System32/LogFiles/Srt/*.log` | 1-5MB | Startup repair logs |
+| `/Windows/bootstat.dat` | 64KB | Boot status/failure tracking |
+| `/Windows/System32/Recovery/ReAgent.xml` | 5KB - 50KB | WinRE configuration |
+
+**Why Important:** When updates cause boot failures, these logs show recovery attempts and boot failure reasons.
+
+**Estimated Files:** 3-5 files | **Estimated Size:** 1MB - 10MB
+
+---
+
+### Windows Error Reporting
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/ProgramData/Microsoft/Windows/WER/ReportArchive/*/*.wer` | 0-50 | 1-100KB each | Archived crash reports |
+| `/ProgramData/Microsoft/Windows/WER/ReportQueue/*/*.wer` | 0-20 | 1-100KB each | Pending crash reports |
+
+**Why Important:** Captures crashes that occurred during update installation.
+
+**Estimated Files:** 0-70 files | **Estimated Size:** 1MB - 10MB
+
+---
+
+### Post-Setup Scripts
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/setupcomplete.log` | 0-1 | 1KB - 1MB | Post-setup script output |
+| `/Windows/Setup/Scripts/*` | 0-5 | 1KB - 1MB each | Custom setup scripts |
+
+**Why Important:** Custom post-upgrade scripts may fail and cause issues.
+
+**Estimated Files:** 0-6 files | **Estimated Size:** <5MB
+
+---
+
+## OS Upgrade Sections
+
+### OS Upgrade - Compatibility Appraiser
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/appcompat/Programs/Appraiser/*.xml` | 1-5 | 1-10MB each | App compatibility assessment |
+| `/Windows/appcompat/Programs/Appraiser/*.bin` | 1-3 | 10-50MB each | Compatibility data |
+
+**Why Important:** Shows what applications/drivers blocked the upgrade.
+
+**Estimated Files:** 2-8 files | **Estimated Size:** 10MB - 100MB
+
+---
+
+### OS Upgrade - Setup API
+
+| File | Typical Size | Purpose |
+|------|--------------|---------|
+| `/Windows/INF/setupapi.upgrade.log` | 5MB - 100MB | Driver migration during upgrade |
+
+**Why Important:** Driver compatibility is the #1 cause of upgrade failures.
+
+**Estimated Files:** 1 file | **Estimated Size:** 5MB - 100MB
+
+---
+
+### OS Upgrade - MoSetup
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `/Windows/Logs/MoSetup/*.log` | 3-10 | 1-20MB each | Modern Setup orchestrator logs |
+| `/Windows/Logs/mosetup/bluebox.log` | 1 | 1-10MB | Feature update orchestration |
+
+**Why Important:** MoSetup orchestrates the entire feature update process.
+
+**Estimated Files:** 4-11 files | **Estimated Size:** 5MB - 100MB
+
+---
+
+### OS Upgrade - Event Logs
+
+| Event Log | Typical Size | Purpose |
+|-----------|--------------|---------|
+| `Microsoft-Windows-Setup%4Operational.evtx` | 1-20MB | Setup operations |
+| `Microsoft-Windows-Upgrade-Diagnostics%4Operational.evtx` | 1-10MB | Upgrade-specific diagnostics |
+
+**Why Important:** Upgrade-specific events with error codes and phase information.
+
+**Estimated Files:** 2 files | **Estimated Size:** 2MB - 30MB
+
+---
+
+### OS Upgrade - Staging Folder ($Windows.~BT)
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `scanresult.xml` | 1 | 100KB - 5MB | Compatibility scan results |
+| `CompatData*.xml` | 1-3 | 100KB - 2MB each | Compatibility data |
+| `setupact.log` | 1 | 10-100MB | Main setup action log |
+| `setuperr.log` | 1 | 1KB - 10MB | Setup errors |
+| `miglog.xml` | 1 | 1-50MB | Migration log |
+| `PreDownload*.log` | 0-2 | 1-5MB each | Pre-download phase |
+| `NewOs*.log` | 0-2 | 1-5MB each | New OS phase |
+| `DDACLSys.log` | 0-1 | 1-5MB | Driver compatibility |
+| `actionlist.xml` | 0-1 | 100KB - 1MB | Pending actions |
+
+**Why Important:** The **primary diagnostic source** for feature update failures. setupact.log contains the full upgrade sequence.
+
+**Estimated Files:** 7-13 files | **Estimated Size:** 20MB - 200MB
+
+---
+
+### OS Upgrade - Rollback
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `setuperr.log` | 1 | 1KB - 10MB | Rollback errors |
+| `diagerr.xml` | 1 | 100KB - 5MB | Diagnostic errors |
+| `diagwrn.xml` | 1 | 100KB - 5MB | Diagnostic warnings |
+| `setupact.log` | 1 | 1-20MB | Rollback actions |
+
+**Why Important:** When upgrades fail and rollback, these logs explain why.
+
+**Estimated Files:** 4 files | **Estimated Size:** 2MB - 40MB
+
+---
+
+### OS Upgrade - SafeOS Phase
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `SafeOS/Panther/setupact.log` | 1 | 1-20MB | WinRE upgrade phase actions |
+| `SafeOS/Panther/setuperr.log` | 1 | 1KB - 5MB | WinRE phase errors |
+
+**Why Important:** SafeOS (WinRE) phase failures are common upgrade blockers.
+
+**Estimated Files:** 2 files | **Estimated Size:** 1MB - 25MB
+
+---
+
+### OS Upgrade - Alternative Staging ($Windows.~WS)
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `setupact.log` | 1 | 1-20MB | Alternative staging actions |
+| `setuperr.log` | 1 | 1KB - 5MB | Errors |
+| `miglog.xml` | 1 | 1-20MB | Migration log |
+
+**Why Important:** Some upgrades use `$Windows.~WS` instead of `$Windows.~BT`.
+
+**Estimated Files:** 3 files | **Estimated Size:** 3MB - 45MB
+
+---
+
+### OS Upgrade - Setup Cleanup
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `SetupCleanupTask/setupact.log` | 1 | 1-10MB | Post-upgrade cleanup |
+| `SetupCleanupTask/setuperr.log` | 1 | 1KB - 1MB | Cleanup errors |
+
+**Why Important:** Cleanup failures can leave the system in a bad state.
+
+**Estimated Files:** 2 files | **Estimated Size:** 1MB - 11MB
+
+---
+
+### OS Upgrade - Previous OS (Windows.old)
+
+| File Pattern | Est. Files | Typical Size | Purpose |
+|--------------|------------|--------------|---------|
+| `mosetup/bluebox.log` | 1 | 1-10MB | Pre-upgrade orchestration |
+| `WindowsUpdate/*.etl` | 1-5 | 5-20MB each | Pre-upgrade WU state |
+| `SoftwareDistribution/ReportingEvents.log` | 1 | 1-5MB | Pre-upgrade WU history |
+| `USOPrivate/UpdateStore` | 1 | 1-10MB | Pre-upgrade USO state |
+| `USOShared/Logs` | 1-5 | 1-10MB each | Pre-upgrade USO logs |
+| `Panther/setupact.log` | 1 | 1-50MB | Pre-upgrade setup log |
+| `Panther/setuperr.log` | 1 | 1KB - 5MB | Pre-upgrade errors |
+| `Panther/miglog.xml` | 1 | 1-20MB | Pre-upgrade migration |
+
+**Why Important:** Contains the state of the system before the upgrade - essential for comparing before/after.
+
+**Estimated Files:** 8-15 files | **Estimated Size:** 15MB - 150MB
+
+---
+
+## Size Summary by Section
+
+| Section | Est. Files | Min Size | Max Size |
+|---------|------------|----------|----------|
+| Registry Hives | 3 | 60MB | 250MB |
+| Event Logs (General) | 3 | 40MB | 275MB |
+| Provisioning | 15-20 | 20MB | 150MB |
+| CBS and Servicing | 15-40 | 50MB | 500MB |
+| WaaS Medic | 1-5 | 1MB | 100MB |
+| Setup API (WU) | 1 | 5MB | 50MB |
+| Logs and ETL | 5-20 | 20MB | 200MB |
+| SoftwareDistribution | 10-50 | 60MB | 600MB |
+| Update Orchestrator | 5-20 | 15MB | 200MB |
+| Update Health Tools | 1-5 | 1MB | 50MB |
+| Delivery Optimization | 3-11 | 10MB | 200MB |
+| WU Event Logs | 11 | 25MB | 250MB |
+| Azure Update Manager | 7-20 | 5MB | 100MB |
+| Startup Repair | 3-5 | 1MB | 10MB |
+| Windows Error Reporting | 0-70 | 1MB | 10MB |
+| Post-Setup Scripts | 0-6 | 0MB | 5MB |
+| Compatibility Appraiser | 2-8 | 10MB | 100MB |
+| Setup API (Upgrade) | 1 | 5MB | 100MB |
+| MoSetup | 4-11 | 5MB | 100MB |
+| OS Upgrade Event Logs | 2 | 2MB | 30MB |
+| Staging ($Windows.~BT) | 7-13 | 20MB | 200MB |
+| Rollback | 4 | 2MB | 40MB |
+| SafeOS Phase | 2 | 1MB | 25MB |
+| Alt Staging ($Windows.~WS) | 3 | 3MB | 45MB |
+| Setup Cleanup | 2 | 1MB | 11MB |
+| Previous OS (Windows.old) | 8-15 | 15MB | 150MB |
+| **TOTAL** | **110-350** | **~350MB** | **~3.2GB** |
+
+---
+
+## Recommendations
+
+### Size Optimization
+
+1. **CBS Cab Files** - Consider tool enhancement for `latest:3` to limit cab collection
+2. **DataStore.edb** - 50-500MB single file; consider making optional
+3. **Event Logs** - Generally acceptable sizes
+4. **ETL Files** - Binary traces; compress well
+
+### Splitting Recommendations
+
+For smaller packages, consider splitting into:
+
+| Manifest | Contents | Est. Size |
+|----------|----------|-----------|
+| `windowsupdate-min` | Event logs + CBS logs only | 100-400MB |
+| `windowsupdate` | Full WU troubleshooting | 200-800MB |
+| `windowsupdate-osupgrade` | OS upgrade specific | 100-500MB |
+| `storeapps` | Microsoft Store / UWP apps | 50-200MB |
+| `windowsupdate-full` | Everything | 400MB-1.5GB |
+

--- a/manifests/windows/diagnostic-cleanup-osupgrade
+++ b/manifests/windows/diagnostic-cleanup-osupgrade
@@ -1,0 +1,4 @@
+echo,### Disk Cleanup Logs ###
+copy,/Windows/Logs/DiskCleanup/DiskCleanup.log
+ll,/Windows/Logs/DiskCleanup
+

--- a/manifests/windows/diagnostic-compat-appraiser-osupgrade
+++ b/manifests/windows/diagnostic-compat-appraiser-osupgrade
@@ -1,0 +1,5 @@
+echo,### OS Upgrade Compatibility Appraiser ###
+copy,/Windows/appcompat/Appraiser*.xml
+copy,/Windows/appcompat/Appraiser*.cab
+ll,/Windows/appcompat/Programs
+

--- a/manifests/windows/diagnostic-eventlogs-client-windowsupdate
+++ b/manifests/windows/diagnostic-eventlogs-client-windowsupdate
@@ -1,0 +1,5 @@
+echo,### Windows Update Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-WindowsUpdateClient%4Operational.evtx
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Servicing%4Admin.evtx
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-WUSA%4Operational.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-do-windowsupdate
+++ b/manifests/windows/diagnostic-eventlogs-do-windowsupdate
@@ -1,0 +1,4 @@
+echo,### Delivery Optimization Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-DeliveryOptimization%4Operational.evtx
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Bits-Client%4Operational.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-general-common
+++ b/manifests/windows/diagnostic-eventlogs-general-common
@@ -1,0 +1,5 @@
+echo,### General Event Logs ###
+copy,/Windows/System32/winevt/Logs/System.evtx
+copy,/Windows/System32/winevt/Logs/Application.evtx
+copy,/Windows/System32/winevt/Logs/Setup.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-grouppolicy-common
+++ b/manifests/windows/diagnostic-eventlogs-grouppolicy-common
@@ -1,0 +1,3 @@
+echo,### Group Policy Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-GroupPolicy%4Operational.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-kernel-common
+++ b/manifests/windows/diagnostic-eventlogs-kernel-common
@@ -1,0 +1,4 @@
+echo,### Kernel and Driver Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Kernel-PnP%4Configuration.evtx
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Kernel-Power%4Operational.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-security-common
+++ b/manifests/windows/diagnostic-eventlogs-security-common
@@ -1,0 +1,4 @@
+echo,### Security and Licensing Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-CAPI2%4Operational.evtx
+copy,/Windows/System32/Winevt/Logs/Microsoft-WS-Licensing%4Admin.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-setup-osupgrade
+++ b/manifests/windows/diagnostic-eventlogs-setup-osupgrade
@@ -1,0 +1,4 @@
+echo,### OS Upgrade Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Setup%4Operational.evtx
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-Upgrade-Diagnostics%4Operational.evtx
+

--- a/manifests/windows/diagnostic-eventlogs-taskscheduler-common
+++ b/manifests/windows/diagnostic-eventlogs-taskscheduler-common
@@ -1,0 +1,3 @@
+echo,### Task Scheduler Event Logs ###
+copy,/Windows/System32/winevt/Logs/Microsoft-Windows-TaskScheduler%4Operational.evtx
+

--- a/manifests/windows/diagnostic-extensions-updatemanager
+++ b/manifests/windows/diagnostic-extensions-updatemanager
@@ -1,0 +1,8 @@
+echo,### Azure Update Manager Extension ###
+copy,/WindowsAzure/Logs/Plugins/Microsoft.CPlat.Core.WindowsPatchExtension/*/*.log
+copy,/Packages/Plugins/Microsoft.CPlat.Core.WindowsPatchExtension/*/status/*.status
+copy,/Packages/Plugins/Microsoft.CPlat.Core.WindowsPatchExtension/*/RuntimeSettings/*.settings
+copy,/Packages/Plugins/Microsoft.CPlat.Core.WindowsPatchExtension/*/config.txt
+copy,/Packages/Plugins/Microsoft.CPlat.Core.WindowsPatchExtension/*/HandlerEnvironment.json
+copy,/Packages/Plugins/Microsoft.CPlat.Core.WindowsPatchExtension/*/HandlerManifest.json
+

--- a/manifests/windows/diagnostic-logs-client-windowsupdate
+++ b/manifests/windows/diagnostic-logs-client-windowsupdate
@@ -1,0 +1,14 @@
+echo,### Windows Update Logs ###
+copy,/Windows/windowsupdate*.log
+copy,/Windows/Logs/WindowsUpdate/WindowsUpdate.*.etl,noscan
+copy,/WindowsUpdateVerbose.etl,noscan
+
+echo,### SIH Logs ###
+copy,/Windows/Logs/SIH/SIH.*.etl,noscan
+
+echo,### DPX Logs ###
+copy,/Windows/Logs/dpx/*.log
+
+echo,### Setup API ###
+copy,/Windows/INF/setupapi.dev.log
+

--- a/manifests/windows/diagnostic-logs-dpx-windowsupdate
+++ b/manifests/windows/diagnostic-logs-dpx-windowsupdate
@@ -1,0 +1,4 @@
+echo,### DPX Logs ###
+copy,/Windows/Logs/DPX/setupact.log
+copy,/Windows/Logs/DPX/setuperr.log
+

--- a/manifests/windows/diagnostic-logs-mosetup-osupgrade
+++ b/manifests/windows/diagnostic-logs-mosetup-osupgrade
@@ -1,0 +1,4 @@
+echo,### OS Upgrade MoSetup Logs ###
+copy,/Windows/Logs/MoSetup/BlueBox.log
+copy,/Windows/Logs/mosetup/UpdateAgent.log
+

--- a/manifests/windows/diagnostic-logs-setupapi-windowsupdate
+++ b/manifests/windows/diagnostic-logs-setupapi-windowsupdate
@@ -1,0 +1,4 @@
+echo,### SetupAPI Logs ###
+copy,/Windows/INF/setupapi.dev.log
+copy,/Windows/INF/setupapi.app.log
+

--- a/manifests/windows/diagnostic-logs-sih-windowsupdate
+++ b/manifests/windows/diagnostic-logs-sih-windowsupdate
@@ -1,0 +1,4 @@
+echo,### SIH Service Logs ###
+copy,/Windows/Logs/SIH/SIH*.log
+copy,/Windows/Logs/SIH/SIH*.etl
+

--- a/manifests/windows/diagnostic-orchestrator-healthtools-windowsupdate
+++ b/manifests/windows/diagnostic-orchestrator-healthtools-windowsupdate
@@ -1,0 +1,5 @@
+echo,### Update Health Tools ###
+copy,/ProgramData/Microsoft/Windows/UpdateHealthTools/*.log
+copy,/ProgramData/Microsoft/Windows/UpdateHealthTools/*.etl
+ll,/ProgramData/Microsoft/Windows/UpdateHealthTools
+

--- a/manifests/windows/diagnostic-orchestrator-uso-windowsupdate
+++ b/manifests/windows/diagnostic-orchestrator-uso-windowsupdate
@@ -1,0 +1,7 @@
+echo,### USO Update Session Orchestrator Logs ###
+copy,/ProgramData/USOPrivate/UpdateStore/*.xml
+copy,/ProgramData/USOShared/Logs/*.log
+copy,/ProgramData/USOShared/Logs/*.etl
+ll,/ProgramData/USOPrivate
+ll,/ProgramData/USOShared
+

--- a/manifests/windows/diagnostic-previousos-osupgrade
+++ b/manifests/windows/diagnostic-previousos-osupgrade
@@ -1,0 +1,5 @@
+echo,### Windows.old Previous Installation ###
+ll,/Windows.old
+copy,/Windows.old/Windows/Panther/setupact.log
+copy,/Windows.old/Windows/Panther/setuperr.log
+

--- a/manifests/windows/diagnostic-provisioning-firstboot-osupgrade
+++ b/manifests/windows/diagnostic-provisioning-firstboot-osupgrade
@@ -1,0 +1,4 @@
+echo,### First Logon Commands ###
+copy,/Windows/Panther/FirstLogonCommands.log
+copy,/Windows/Panther/Specialize.log
+

--- a/manifests/windows/diagnostic-provisioning-panther-osupgrade
+++ b/manifests/windows/diagnostic-provisioning-panther-osupgrade
@@ -1,0 +1,10 @@
+echo,### Panther Setup Logs ###
+copy,/Windows/Panther/setupact.log
+copy,/Windows/Panther/setuperr.log
+copy,/Windows/Panther/UnattendGC/setupact.log
+copy,/Windows/Panther/UnattendGC/setuperr.log
+copy,/Windows/Panther/cbs_unattend.log
+copy,/Windows/Panther/DDACLSys.log
+copy,/Windows/Panther/UnattendedJoin/UnattendedJoinDCLocator.etl
+copy,/Windows/Panther/miglog.xml
+

--- a/manifests/windows/diagnostic-provisioning-state-osupgrade
+++ b/manifests/windows/diagnostic-provisioning-state-osupgrade
@@ -1,0 +1,4 @@
+echo,### Provisioning State ###
+copy,/Windows/Setup/State/State.ini
+ll,/Windows/Setup/State
+

--- a/manifests/windows/diagnostic-provisioning-sysprep-osupgrade
+++ b/manifests/windows/diagnostic-provisioning-sysprep-osupgrade
@@ -1,0 +1,8 @@
+echo,### Sysprep Files ###
+copy,/Windows/System32/Sysprep/Panther/setupact.log
+copy,/Windows/System32/Sysprep/Panther/setuperr.log
+copy,/Windows/System32/Sysprep/Panther/IE/setupact.log
+copy,/Windows/System32/Sysprep/Sysprep_succeeded.tag
+copy,/Windows/System32/Sysprep/Unattend.xml
+ll,/Windows/System32/Sysprep
+

--- a/manifests/windows/diagnostic-recovery-postsetup-osupgrade
+++ b/manifests/windows/diagnostic-recovery-postsetup-osupgrade
@@ -1,0 +1,4 @@
+echo,### Post-Setup Actions ###
+copy,/Windows/Logs/mosetup/UpdateAgent.log
+copy,/Windows/Logs/MoSetup/BlueBox.log
+

--- a/manifests/windows/diagnostic-recovery-startuprepair-osupgrade
+++ b/manifests/windows/diagnostic-recovery-startuprepair-osupgrade
@@ -1,0 +1,5 @@
+echo,### Startup Repair Logs ###
+copy,/Windows/System32/LogFiles/Srt/SrtTrail.txt
+copy,/Windows/System32/LogFiles/Srt/srt-ui-*.txt
+ll,/Windows/System32/LogFiles/Srt
+

--- a/manifests/windows/diagnostic-recovery-wer-osupgrade
+++ b/manifests/windows/diagnostic-recovery-wer-osupgrade
@@ -1,0 +1,4 @@
+echo,### Windows Error Reporting ReportQueue ###
+ll,/ProgramData/Microsoft/Windows/WER/ReportQueue
+copy,/ProgramData/Microsoft/Windows/WER/ReportQueue/*/Report.wer
+

--- a/manifests/windows/diagnostic-registry-bcd-common
+++ b/manifests/windows/diagnostic-registry-bcd-common
@@ -1,0 +1,3 @@
+echo,### BCD Registry Hive ###
+copy,/Boot/BCD,noscan
+

--- a/manifests/windows/diagnostic-registry-components-windowsupdate
+++ b/manifests/windows/diagnostic-registry-components-windowsupdate
@@ -1,0 +1,3 @@
+echo,### Component Based Servicing Registry ###
+copy,/Windows/System32/config/COMPONENTS,noscan
+

--- a/manifests/windows/diagnostic-registry-software-common
+++ b/manifests/windows/diagnostic-registry-software-common
@@ -1,0 +1,3 @@
+echo,### SOFTWARE Registry Hive ###
+copy,/Windows/System32/config/SOFTWARE,noscan
+

--- a/manifests/windows/diagnostic-registry-system-common
+++ b/manifests/windows/diagnostic-registry-system-common
@@ -1,0 +1,3 @@
+echo,### SYSTEM Registry Hive ###
+copy,/Windows/System32/config/SYSTEM,noscan
+

--- a/manifests/windows/diagnostic-servicing-cbs-windowsupdate
+++ b/manifests/windows/diagnostic-servicing-cbs-windowsupdate
@@ -1,0 +1,5 @@
+echo,### CBS Component Servicing Logs ###
+copy,/Windows/Logs/CBS/CBS.log
+copy,/Windows/Logs/CBS/CbsPersist*.log
+copy,/Windows/Logs/CBS/CbsPersist*.cab
+

--- a/manifests/windows/diagnostic-servicing-dism-windowsupdate
+++ b/manifests/windows/diagnostic-servicing-dism-windowsupdate
@@ -1,0 +1,4 @@
+echo,### DISM Logs ###
+copy,/Windows/Logs/DISM/dism.log
+copy,/Windows/Logs/DISM/dism_*.log
+

--- a/manifests/windows/diagnostic-servicing-sessions-windowsupdate
+++ b/manifests/windows/diagnostic-servicing-sessions-windowsupdate
@@ -1,0 +1,5 @@
+echo,### Servicing Sessions ###
+copy,/Windows/servicing/Sessions.xml
+copy,/Windows/servicing/Sessions/Sessions.xml
+ll,/Windows/servicing/Sessions
+

--- a/manifests/windows/diagnostic-servicing-sfc-windowsupdate
+++ b/manifests/windows/diagnostic-servicing-sfc-windowsupdate
@@ -1,0 +1,3 @@
+echo,### SFC Servicing Logs ###
+copy,/Windows/Logs/CBS/sfc*.log
+

--- a/manifests/windows/diagnostic-servicing-waasmedic-windowsupdate
+++ b/manifests/windows/diagnostic-servicing-waasmedic-windowsupdate
@@ -1,0 +1,4 @@
+echo,### WaaS Medic Service Logs ###
+copy,/Windows/Logs/waasmedic/waasmedic.log
+copy,/Windows/Logs/waasmedic/WaaSMedic*.etl
+

--- a/manifests/windows/diagnostic-softwaredistribution-datastore-windowsupdate
+++ b/manifests/windows/diagnostic-softwaredistribution-datastore-windowsupdate
@@ -1,0 +1,4 @@
+echo,### Windows Update DataStore ###
+copy,/Windows/SoftwareDistribution/DataStore/DataStore.edb,noscan
+copy,/Windows/SoftwareDistribution/DataStore/Logs/*.log
+

--- a/manifests/windows/diagnostic-softwaredistribution-do-windowsupdate
+++ b/manifests/windows/diagnostic-softwaredistribution-do-windowsupdate
@@ -1,0 +1,5 @@
+echo,### Delivery Optimization Logs ###
+copy,/Windows/SoftwareDistribution/DeliveryOptimization*.log
+copy,/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Logs/*.log
+copy,/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Logs/*.etl
+

--- a/manifests/windows/diagnostic-softwaredistribution-download-windowsupdate
+++ b/manifests/windows/diagnostic-softwaredistribution-download-windowsupdate
@@ -1,0 +1,5 @@
+echo,### Windows Update Download Metadata ###
+ll,/Windows/SoftwareDistribution/Download
+copy,/Windows/SoftwareDistribution/Download/*.log
+copy,/Windows/SoftwareDistribution/SLS/*.log
+

--- a/manifests/windows/diagnostic-softwaredistribution-plugins-windowsupdate
+++ b/manifests/windows/diagnostic-softwaredistribution-plugins-windowsupdate
@@ -1,0 +1,3 @@
+echo,### Windows Update Plugins ###
+ll,/Windows/SoftwareDistribution/Plugins
+

--- a/manifests/windows/diagnostic-softwaredistribution-reporting-windowsupdate
+++ b/manifests/windows/diagnostic-softwaredistribution-reporting-windowsupdate
@@ -1,0 +1,3 @@
+echo,### Windows Update Reporting Events ###
+copy,/Windows/SoftwareDistribution/ReportingEvents.log
+

--- a/manifests/windows/diagnostic-staging-bt-osupgrade
+++ b/manifests/windows/diagnostic-staging-bt-osupgrade
@@ -1,0 +1,22 @@
+echo,### Staging Folder - $Windows.~BT ###
+copy,/$WINDOWS.~BT/Sources/Panther/scanresult.xml 
+copy,/$Windows.~BT/Sources/Panther/CompatData*.xml
+copy,/$Windows.~BT/Sources/Panther/setupact.log
+copy,/$Windows.~BT/Sources/Panther/setuperr.log
+copy,/$Windows.~BT/Sources/Panther/miglog.xml
+copy,/$Windows.~BT/Sources/Panther/PreDownload*.log
+copy,/$Windows.~BT/Sources/Panther/NewOs*.log
+copy,/$Windows.~BT/Sources/Panther/DDACLSys.log
+copy,/$Windows.~BT/Sources/Panther/actionlist.xml
+copy,/Windows/Panther/miglog.xml
+
+echo,### Rollback Logs ###
+copy,/$Windows.~BT/Sources/Rollback/setuperr.log
+copy,/$Windows.~BT/Sources/Rollback/diagerr.xml
+copy,/$Windows.~BT/Sources/Rollback/diagwrn.xml
+copy,/$Windows.~BT/Sources/Rollback/setupact.log
+
+echo,### SafeOS Phase ###
+copy,/$Windows.~BT/Sources/SafeOS/Panther/setupact.log
+copy,/$Windows.~BT/Sources/SafeOS/Panther/setuperr.log
+

--- a/manifests/windows/diagnostic-staging-safeos-osupgrade
+++ b/manifests/windows/diagnostic-staging-safeos-osupgrade
@@ -1,0 +1,5 @@
+echo,### OS Upgrade SafeOS DU ###
+ll,/$Windows.~BT/Sources/SafeOS/SafeOS.Mount
+copy,/$Windows.~BT/Sources/SafeOS/setupact.log
+copy,/$Windows.~BT/Sources/SafeOS/setuperr.log
+

--- a/manifests/windows/diagnostic-staging-ws-osupgrade
+++ b/manifests/windows/diagnostic-staging-ws-osupgrade
@@ -1,0 +1,19 @@
+echo,### Alternative Staging Folder - $Windows.~WS ###
+copy,/$Windows.~WS/Sources/Panther/setupact.log
+copy,/$Windows.~WS/Sources/Panther/setuperr.log
+copy,/$Windows.~WS/Sources/Panther/miglog.xml
+
+echo,### Setup Cleanup ###
+copy,/Windows/Logs/SetupCleanupTask/setupact.log
+copy,/Windows/Logs/SetupCleanupTask/setuperr.log
+
+echo,### Previous OS - Windows.old ###
+copy,/Windows.old/Windows/Logs/mosetup/bluebox.log
+copy,/Windows.old/Windows/Logs/WindowsUpdate/*.etl,noscan
+copy,/Windows.old/Windows/SoftwareDistribution/ReportingEvents.log
+copy,/Windows.old/ProgramData/USOPrivate/UpdateStore
+copy,/Windows.old/ProgramData/USOShared/Logs
+copy,/Windows.old/Windows/Panther/setupact.log
+copy,/Windows.old/Windows/Panther/setuperr.log
+copy,/Windows.old/Windows/Panther/miglog.xml
+


### PR DESCRIPTION
PR: Modularize Windows Update and OS Upgrade Manifests
Summary
Splits Windows Update and OS Upgrade diagnostic collection into 43 granular manifests for AI-driven selection, following the same pattern established for Linux manifests.

Changes
New Manifests (43 total)

Event Logs: 8 manifests (general, WU client, DO, setup, taskscheduler, kernel, security, grouppolicy)
Registry: 4 manifests (BCD, SYSTEM, SOFTWARE, COMPONENTS)
Servicing: 5 manifests (CBS, DISM, sessions, SFC, WaaS Medic)
Software Distribution: 5 manifests (reporting, DO, plugins, download, datastore)
Orchestrator: 2 manifests (USO, health tools)
Provisioning: 4 manifests (panther, sysprep, state, firstboot)
Staging: 3 manifests (BT, WS, SafeOS)
Recovery: 3 manifests (startup repair, WER, post-setup)
Logs: 5 manifests (client, SIH, DPX, setupapi, mosetup)
OS Upgrade: 4 manifests (appraiser, previousos, cleanup)
Naming Convention
diagnostic-<category>-<subcategory>-<windowsupdate|osupgrade|common>

Documentation

10 new area-specific docs in [windows](vscode-file://vscode-app/c:/Users/scotro/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated [diagnostic-windowsupdate.md](vscode-file://vscode-app/c:/Users/scotro/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as modular reference with links
No Breaking Changes

Original windowsupdate manifest preserved