### PR TITLE
Prototype of modules for Linux Diagnostic modules #310

### DIFF
--- a/docs/manifests/linux/diagnostic-azure-agent.md
+++ b/docs/manifests/linux/diagnostic-azure-agent.md
@@ -1,0 +1,62 @@
+# Azure Agent Diagnostic Manifests
+
+Modular manifests for Azure Linux Agent (waagent) diagnostics.
+
+## Available Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-azure-agent-probing` | Directory listings for /var/log and /var/lib/waagent | None |
+| `diagnostic-azure-agent-config` | waagent.conf configuration | None |
+| `diagnostic-azure-agent-logs` | waagent log files | Low |
+| `diagnostic-azure-agent-state` | Agent state, status, incarnation, history | None |
+| `diagnostic-azure-agent-xml` | SharedConfig, GoalState, ExtensionsConfig XML | Low |
+| `diagnostic-azure-agent-identity` | ManagedIdentity JSON files | **Medium** |
+| `diagnostic-azure-agent-proxyagent` | Guest ProxyAgent logs | Low |
+
+## Issue Type Selection
+
+### General Azure Agent Issues
+```
+diagnostic-azure-agent-probing
+diagnostic-azure-agent-config
+diagnostic-azure-agent-logs
+diagnostic-azure-agent-state
+diagnostic-azure-agent-xml
+```
+
+### Managed Identity Issues
+```
+diagnostic-azure-agent-identity
+diagnostic-azure-agent-logs
+diagnostic-azure-agent-state
+```
+
+### ProxyAgent Issues
+```
+diagnostic-azure-agent-proxyagent
+diagnostic-azure-agent-logs
+```
+
+### Provisioning Issues
+```
+diagnostic-azure-agent-probing
+diagnostic-azure-agent-config
+diagnostic-azure-agent-logs
+diagnostic-azure-agent-state
+diagnostic-azure-agent-xml
+diagnostic-cloudinit-common
+```
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-azure-agent-probing | < 50 KB |
+| diagnostic-azure-agent-config | < 10 KB |
+| diagnostic-azure-agent-logs | 1-50 MB |
+| diagnostic-azure-agent-state | < 5 MB |
+| diagnostic-azure-agent-xml | 100 KB - 5 MB |
+| diagnostic-azure-agent-identity | < 100 KB |
+| diagnostic-azure-agent-proxyagent | 1-10 MB |
+

--- a/docs/manifests/linux/diagnostic-azure-files.md
+++ b/docs/manifests/linux/diagnostic-azure-files.md
@@ -1,0 +1,60 @@
+# Azure Files Diagnostic Manifests
+
+Modular manifests for Azure cloud and storage integration diagnostics.
+
+## Available Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-cloudinit-common` | Cloud-init provisioning logs and config | Low |
+| `diagnostic-blobfuse-common` | Blobfuse mount logs | None |
+
+## Issue Type Selection
+
+### VM Provisioning Issues
+```
+diagnostic-cloudinit-common
+diagnostic-azure-agent-logs
+diagnostic-azure-agent-state
+```
+
+### Blobfuse Mount Issues
+```
+diagnostic-blobfuse-common
+diagnostic-syslog-common
+diagnostic-fstab-common
+```
+
+### Cloud-init Issues
+```
+diagnostic-cloudinit-common
+diagnostic-syslog-common
+diagnostic-kernlog-common
+```
+
+## Manifest Details
+
+### diagnostic-cloudinit-common
+
+Collects cloud-init provisioning files:
+- `/var/log/cloud-init*` - Cloud-init logs
+- `/etc/cloud/cloud.cfg` - Main cloud-init config
+- `/etc/cloud/cloud.cfg.d/*.cfg` - Config includes
+- `/run/cloud-init/cloud.cfg` - Runtime config
+- `/run/cloud-init/ds-identify.log` - Datasource identification
+- `/run/cloud-init/result.json` - Provisioning result
+- `/run/cloud-init/status.json` - Provisioning status
+
+### diagnostic-blobfuse-common
+
+Collects blobfuse mount logs:
+- `/var/log/blobfuse*` - Blobfuse v1 logs
+- `/var/log/blobfuse2.log*` - Blobfuse v2 logs
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-cloudinit-common | 500 KB - 2 MB |
+| diagnostic-blobfuse-common | < 10 MB |
+

--- a/docs/manifests/linux/diagnostic-extensions.md
+++ b/docs/manifests/linux/diagnostic-extensions.md
@@ -1,0 +1,88 @@
+# Azure Extensions Diagnostic Manifests
+
+Modular manifests for Azure VM extension diagnostics.
+
+## Core Extension Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-extensions-probing` | Directory listings for extension dirs | None |
+| `diagnostic-extensions-handler` | Handler config, state, status files | Low |
+| `diagnostic-extensions-logs` | Extension logs from /var/log/azure | Low |
+
+## Extension-Specific Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-extensions-monitoring` | Azure Monitor Agent - AMA | Low |
+| `diagnostic-extensions-lad` | Linux Diagnostic Extension | Low |
+| `diagnostic-extensions-siterecovery` | Site Recovery Extension | Low |
+| `diagnostic-extensions-sqliaas` | SQL IaaS Extension | Low |
+| `diagnostic-extensions-workloadbackup` | Workload Backup - SAP HANA | Low |
+| `diagnostic-extensions-servicefabric` | Service Fabric and Key Vault | Low |
+
+## Issue Type Selection
+
+### General Extension Handler Issues
+```
+diagnostic-extensions-probing
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Azure Monitor Agent Issues
+```
+diagnostic-extensions-monitoring
+diagnostic-extensions-probing
+diagnostic-extensions-logs
+```
+
+### Linux Diagnostic Extension Issues
+```
+diagnostic-extensions-lad
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Site Recovery Issues
+```
+diagnostic-extensions-siterecovery
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### SQL IaaS Issues
+```
+diagnostic-extensions-sqliaas
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Workload Backup Issues
+```
+diagnostic-extensions-workloadbackup
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Service Fabric Issues
+```
+diagnostic-extensions-servicefabric
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-extensions-probing | < 100 KB |
+| diagnostic-extensions-handler | 100 KB - 1 MB |
+| diagnostic-extensions-logs | 1-50 MB |
+| diagnostic-extensions-monitoring | 1-20 MB |
+| diagnostic-extensions-lad | 1-10 MB |
+| diagnostic-extensions-siterecovery | 1-10 MB |
+| diagnostic-extensions-sqliaas | 1-20 MB |
+| diagnostic-extensions-workloadbackup | 5-50 MB |
+| diagnostic-extensions-servicefabric | 1-10 MB |
+

--- a/docs/manifests/linux/diagnostic-hpc-common.md
+++ b/docs/manifests/linux/diagnostic-hpc-common.md
@@ -1,0 +1,96 @@
+# diagnostic-hpc-common Manifest Documentation
+
+## Summary
+
+| Attribute | Value |
+|-----------|-------|
+| **Manifest** | `diagnostic-hpc-common` |
+| **Platform** | Linux (All Distributions) |
+| **Purpose** | Collect HPC (High Performance Computing) diagnostic data |
+| **Total Items** | ~45 entries |
+| **Estimated Size** | 5-50 MB (varies with HPC workload) |
+
+## Description
+
+This manifest collects diagnostic data specific to High Performance Computing (HPC) environments on Azure, including GPU/NVIDIA drivers, job schedulers (Slurm, PBS, SGE), and InfiniBand networking status. This is a modular manifest designed to be combined with distro-specific manifests.
+
+## Sections
+
+### Probing HPC Directories
+| Path | Type | X |
+|------|------|---|
+| `/sys/class/infiniband/` | ll | |
+| `/sched/sge/` | ll | |
+| `/var/log/slurmctld/` | ll | |
+| `/var/log/slurmd/` | ll | |
+| `/var/spool/pbs/` | ll | |
+
+### NVIDIA/CUDA Installer Logs
+| Path | Type | X |
+|------|------|---|
+| `/var/log/cuda-installer.log` | copy | |
+| `/var/log/nvidia-installer.log` | copy | |
+
+### Slurm Files
+| Path | Type | X |
+|------|------|---|
+| `/etc/slurm/*` | copy | |
+| `/var/log/slurmctld/slurmctld.log` | copy | X |
+| `/var/log/slurmd/slurmd.log` | copy | X |
+
+### PBS Files
+| Path | Type | X |
+|------|------|---|
+| `/etc/pbs.conf` | copy | |
+| `/var/spool/pbs/mom_logs/*` | copy | X |
+| `/var/spool/pbs/sched_logs/*` | copy | X |
+
+### SGE Files
+| Path | Type | X |
+|------|------|---|
+| `/sched/sge/sge-2011.11/default/common/install_logs/*` | copy | |
+| `/sched/sge/sge-2011.11/default/spool/*` | copy | X |
+
+### System Limits
+| Path | Type | X |
+|------|------|---|
+| `/etc/security/limits.conf` | copy,noscan | |
+
+### InfiniBand State
+| Path | Type | X |
+|------|------|---|
+| `/sys/class/infiniband/mlx5_ib[0-7]/ports/1/state` | copy,noscan | |
+| `/sys/class/infiniband/mlx5_ib[0-7]/ports/1/rate` | copy,noscan | |
+| `/sys/class/infiniband/mlx5_ib[0-7]/ports/1/phys_state` | copy,noscan | |
+| `/sys/class/infiniband/mlx5_ib[0-7]/ports/1/pkeys` | copy,noscan | |
+
+*Note: InfiniBand entries cover 8 adapters (mlx5_ib0 through mlx5_ib7) with 4 attributes each (32 total sysfs entries)*
+
+## PII Indicators
+
+| Symbol | Meaning |
+|--------|---------|
+| X | May contain PII (job names, usernames, hostnames) |
+| (blank) | No PII expected |
+
+## Usage Notes
+
+- **Modular Design**: Combine with distro-specific manifests (e.g., `diagnostic-ubuntu` + `diagnostic-hpc`)
+- **HPC VMs**: Primarily useful for H-series and N-series VMs with InfiniBand or GPU
+- **Extension Logs**: For HPC extension logs (`/var/log/azure/ib-vmext-status/`, `/var/log/azure/nvidia-vmext-status/`), use the `azure-extensions` manifest
+- **InfiniBand**: The 8 adapter entries (mlx5_ib0-7) cover most Azure HB/HC/NDv2/NDv4 configurations
+
+## Potentially Missing Items
+
+| Path | Description |
+|------|-------------|
+| `/var/log/mlnx_*` | Mellanox driver logs |
+| `/etc/libibverbs.d/*` | InfiniBand verbs configuration |
+| `/etc/rdma/*` | RDMA configuration files |
+| `/var/log/nvidia-smi.log` | NVIDIA SMI output logs |
+| `/etc/nvidia/*` | NVIDIA configuration files |
+| `/var/log/dcgm/*` | NVIDIA Data Center GPU Manager logs |
+| `/opt/intel/mpi/*/etc/*` | Intel MPI configuration |
+| `/etc/openmpi/*` | OpenMPI configuration |
+| `/var/spool/slurm/*` | Slurm spool files |
+| `/etc/munge/*` | MUNGE authentication for Slurm |

--- a/docs/manifests/linux/diagnostic-hpc.md
+++ b/docs/manifests/linux/diagnostic-hpc.md
@@ -1,0 +1,72 @@
+# HPC Diagnostic Manifests
+
+Modular manifests for High Performance Computing troubleshooting.
+
+## Available Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-hpc-common` | InfiniBand, Slurm, PBS, SGE, NVIDIA | **Medium** |
+
+## Contents
+
+The `diagnostic-hpc-common` manifest collects:
+
+### InfiniBand
+- `/sys/class/infiniband/` directory listing
+- mlx5_ib0-7 port state, rate, phys_state, pkeys
+
+### Job Schedulers
+- Slurm: `/etc/slurm/*`, slurmctld.log, slurmd.log
+- PBS: `/etc/pbs.conf`, mom_logs, sched_logs
+- SGE: install_logs, spool files
+
+### GPU/NVIDIA
+- `/var/log/cuda-installer.log`
+- `/var/log/nvidia-installer.log`
+
+### System Limits
+- `/etc/security/limits.conf`
+
+## Issue Type Selection
+
+### InfiniBand Connectivity
+```
+diagnostic-hpc-common
+diagnostic-kernlog-common
+diagnostic-udev-common
+```
+
+### GPU/NVIDIA Issues
+```
+diagnostic-hpc-common
+diagnostic-kernlog-common
+diagnostic-syslog-common
+```
+
+### Slurm Job Failures
+```
+diagnostic-hpc-common
+diagnostic-syslog-common
+diagnostic-authlog-common
+```
+
+### PBS/SGE Issues
+```
+diagnostic-hpc-common
+diagnostic-syslog-common
+```
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-hpc-common | 5-50 MB |
+
+## Azure VM Series
+
+This manifest is primarily useful for:
+- H-series (HB, HC, HBv2, HBv3, HBv4)
+- N-series (NC, ND, NV)
+- VMs with InfiniBand or GPU
+

--- a/docs/manifests/linux/diagnostic-kubernetes.md
+++ b/docs/manifests/linux/diagnostic-kubernetes.md
@@ -1,0 +1,79 @@
+# Kubernetes and AKS Diagnostic Manifests
+
+Modular manifests for Kubernetes and AKS node troubleshooting.
+
+## General Kubernetes
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-kubernetes-common` | kubelet, containerd, pod logs | **Medium** |
+
+## AKS-Specific Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-probing-aks` | AKS directory listings | None |
+| `diagnostic-provision-aks` | Cluster provisioning scripts | Low |
+| `diagnostic-kubernetes-aks` | kubelet, containerd, journal logs | **Medium** |
+| `diagnostic-pods-aks` | kube-system, calico, tigera pod logs | **Medium** |
+| `diagnostic-networking-aks` | CNI, VNET, IPAM, CNS, NPM logs | None |
+
+## Issue Type Selection
+
+### General AKS Issues
+```
+diagnostic-probing-aks
+diagnostic-provision-aks
+diagnostic-kubernetes-aks
+diagnostic-pods-aks
+diagnostic-networking-aks
+```
+
+### AKS Node Provisioning Issues
+```
+diagnostic-probing-aks
+diagnostic-provision-aks
+diagnostic-cloudinit-common
+diagnostic-azure-agent-logs
+```
+
+### AKS Networking Issues
+```
+diagnostic-networking-aks
+diagnostic-pods-aks
+diagnostic-netconfig-<distro>
+diagnostic-dns-common
+```
+
+### Kubelet Issues
+```
+diagnostic-kubernetes-aks
+diagnostic-syslog-common
+diagnostic-kernlog-common
+```
+
+### Pod Scheduling Issues
+```
+diagnostic-pods-aks
+diagnostic-kubernetes-aks
+diagnostic-syslog-common
+```
+
+### Container Runtime Issues
+```
+diagnostic-kubernetes-aks
+diagnostic-kernlog-common
+diagnostic-syslog-common
+```
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-kubernetes-common | 5-50 MB |
+| diagnostic-probing-aks | < 100 KB |
+| diagnostic-provision-aks | 1-5 MB |
+| diagnostic-kubernetes-aks | 5-50 MB |
+| diagnostic-pods-aks | 5-50 MB |
+| diagnostic-networking-aks | 1-10 MB |
+

--- a/docs/manifests/linux/diagnostic-mariner.md
+++ b/docs/manifests/linux/diagnostic-mariner.md
@@ -1,0 +1,239 @@
+# Azure Disk Inspect: diagnostic-mariner Manifest
+
+This document describes the `diagnostic-mariner` manifest used by the Azure Disk Inspect Service (IID/Ghostfish) to collect diagnostic files from Azure Linux (CBL-Mariner) VMs.
+
+**Note:** For Azure Agent and extension issues, use the `azure-agent` and `azure-extensions` manifests alongside this one.
+
+## Summary
+
+| Section | File Count (Est.) | Size (Est.) | Notes |
+|---------|-------------------|-------------|-------|
+| Probing Directories | 15 listings | Minimal | Directory listings only |
+| DHCP Files | 3-6 files | < 50 KB | NM and systemd-networkd leases |
+| Networking Files | 10-15 files | < 200 KB | ssh, hosts, pam |
+| NetworkManager Files | 5-15 files | < 100 KB | NM configuration |
+| systemd-networkd Files | 5-10 files | < 100 KB | Network unit files |
+| Firewall Files | 3-10 files | < 100 KB | iptables, nftables, firewalld |
+| Package Management (TDNF) | 5-15 files | 100 KB - 1 MB | TDNF/DNF logs |
+| System Log Files | 15-30 files | 10-100 MB | messages, secure, kern |
+| System Configuration | 15-25 files | < 500 KB | fstab, SELinux, sudoers |
+| Disk Info | 1 item | < 100 KB | Disk partition layout |
+| Kubernetes/Container | 10-50 files | 5-50 MB | kubelet, containerd, pods |
+
+**Total Estimated Size:** 20-175 MB depending on log retention and AKS workloads
+
+---
+
+## Section Details
+
+### 1. Probing Directories (15 items)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/boot` | Kernel and boot files | |
+| `/var/log` | Log directory structure | |
+| `/var/lib/cloud` | Cloud-init state | |
+| `/var/lib/waagent` | Azure Agent state | |
+| `/etc` | Configuration overview | |
+| `/etc/udev/rules.d` | Device rules | |
+| `/etc/alternatives` | System alternatives | |
+| `/etc/systemd/system` | Custom systemd units | |
+| `/etc/systemd/system/multi-user.target.wants` | Multi-user services | |
+| `/etc/systemd/system/graphical.target.wants` | Graphical services | |
+| `/etc/systemd/user` | User systemd units | |
+| `/etc/yum.repos.d` | YUM repository configs (compat) | |
+| `/etc/tdnf` | TDNF configuration | |
+| `/usr/lib/systemd/system` | Vendor systemd units | |
+| `/usr/lib/systemd/user` | Vendor user units | |
+
+### 2. DHCP Files - Mariner (3-6 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/lib/NetworkManager/*.lease` | NetworkManager leases | |
+| `/var/lib/NetworkManager/*.leases` | NM leases (alternate) | |
+| `/run/systemd/netif/leases/*` | systemd-networkd leases | |
+
+### 3. Networking Files (10-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/dhcp/*.conf` | DHCP client config | |
+| `/etc/ssh/sshd_config` | SSH daemon config | |
+| `/etc/ssh/sshd_config.d/*` | SSH config includes | |
+| `/etc/nsswitch.conf` | Name service switch | |
+| `/etc/resolv.conf` | DNS resolver config | |
+| `/etc/hosts` | Static host mappings | X |
+| `/etc/hosts.allow` | TCP wrappers allow | |
+| `/etc/hosts.deny` | TCP wrappers deny | |
+| `/etc/pam.d/*` | PAM configuration | X |
+
+### 4. NetworkManager Files (5-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/usr/lib/NetworkManager/*.conf` | Vendor NM config | |
+| `/usr/lib/NetworkManager/conf.d/*.conf` | Vendor NM includes | |
+| `/etc/NetworkManager/*.conf` | System NM config | |
+| `/etc/NetworkManager/conf.d/*.conf` | System NM includes | |
+| `/var/lib/NetworkManager/*.conf` | Runtime NM config | |
+| `/var/lib/NetworkManager/conf.d/*.conf` | Runtime NM includes | |
+| `/var/lib/NetworkManager/*.state` | NM state files | |
+
+### 5. systemd-networkd Files - Mariner (5-10 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/systemd/network/*.network` | Network unit files | |
+| `/etc/systemd/network/*.netdev` | Network device files | |
+| `/etc/systemd/network/*.link` | Link configuration | |
+| `/run/systemd/network/*.network` | Runtime network config | |
+| `/usr/lib/systemd/network/*.network` | Vendor network config | |
+
+### 6. Firewall Files - Mariner (3-10 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/sysconfig/iptables` | iptables rules | |
+| `/etc/nftables.conf` | nftables configuration | |
+| `/etc/firewalld/*.xml` | firewalld config | |
+| `/etc/firewalld/zones/*.xml` | firewalld zones | |
+
+### 7. Package Management Log Files - TDNF (5-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/tdnf*` | TDNF package manager logs | |
+| `/var/log/dnf*` | DNF logs (if installed) | |
+| `/var/log/yum*` | YUM logs (compatibility) | |
+| `/var/cache/tdnf/history/*` | TDNF transaction history | |
+
+### 8. System Log Files (15-30 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/messages*` | System messages | |
+| `/var/log/syslog*` | Syslog (fallback) | |
+| `/var/log/rsyslog*` | Rsyslog output | |
+| `/var/log/kern*` | Kernel messages | |
+| `/var/log/dmesg*` | Boot ring buffer | |
+| `/var/log/boot*` | Boot logs | |
+| `/var/log/auth*` | Authentication log | X |
+| `/var/log/secure*` | Secure log | X |
+| `/var/log/pacemaker*` | Pacemaker cluster | |
+| `/var/log/corosync*` | Corosync cluster | |
+| `/var/log/cluster/*` | Cluster logs | |
+| `/var/log/pacemaker/*` | Pacemaker directory | |
+| `/var/log/corosync/*` | Corosync directory | |
+
+### 9. System Configuration Files (15-25 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/fstab` | Filesystem mounts | |
+| `/etc/crypttab` | Encrypted volumes | X |
+| `/etc/*-release` | OS release info | |
+| `/etc/mariner-release` | Mariner version | |
+| `/etc/HOSTNAME` | Hostname (legacy) | |
+| `/etc/hostname` | Hostname | |
+| `/etc/localtime` | Timezone symlink | |
+| `/etc/chrony/chrony.conf` | Chrony NTP config | |
+| `/etc/chrony.conf` | Chrony config (alt path) | |
+| `/etc/idmapd.conf` | NFSv4 ID mapping | |
+| `/etc/sudoers` | Sudo configuration | X |
+| `/etc/sudoers.d/*` | Sudo includes | X |
+| `/etc/sysctl.conf` | Kernel parameters | |
+| `/etc/sysctl.d/*.conf` | Sysctl includes | |
+| `/etc/udev/rules.d/*.rules` | Device rules | |
+| `/etc/modprobe.d/*.conf` | Kernel module config | |
+| `/etc/security/limits.conf` | Resource limits | |
+| `/etc/selinux/config` | SELinux configuration | |
+
+### 10. Disk Info (1 item)
+
+| Command | Purpose | X |
+|---------|---------|---|
+| `diskinfo,` | Disk partition info | |
+
+### 11. Kubernetes/Container Files - Mariner (10-50 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/pods/*/*/*.log` | Pod logs | |
+| `/var/log/containers/*.log` | Container logs | |
+| `/etc/kubernetes/*.conf` | Kubernetes configs | |
+| `/etc/kubernetes/*.yaml` | Kubernetes YAML configs | |
+| `/var/lib/kubelet/config.yaml` | Kubelet configuration | |
+| `/var/log/kubelet.log` | Kubelet logs | |
+| `/etc/containerd/config.toml` | Containerd config | |
+| `/var/log/containerd.log` | Containerd logs | |
+
+---
+
+## Legend
+
+**X Column:** Items marked with X may contain sensitive or personally identifiable information (PII):
+- Authentication logs with usernames
+- Sudo user configurations
+- Host-specific network information
+- Encrypted volume information
+
+---
+
+## Azure Linux (CBL-Mariner) Characteristics
+
+| Characteristic | Details |
+|----------------|---------|
+| Package Manager | TDNF (Tiny DNF) |
+| Security Framework | SELinux |
+| Network Manager | NetworkManager or systemd-networkd |
+| Init System | systemd |
+| Package Format | RPM |
+| Primary Use Case | AKS nodes, container workloads |
+
+---
+
+## Potentially Missing Items
+
+### Boot and Kernel
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| GRUB configuration | `/boot/grub2/grub.cfg`, `/etc/default/grub` | Boot parameter issues |
+| Kernel crash dumps | `/var/crash/*` | Kernel panic analysis |
+| dracut logs | `/var/log/dracut.log` | initramfs issues |
+
+### TDNF/Package Management
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| TDNF configuration | `/etc/tdnf/tdnf.conf` | Package manager settings |
+| TDNF repos | `/etc/yum.repos.d/*.repo` | Repository definitions |
+| GPG keys | `/etc/pki/rpm-gpg/*` | Package signing |
+
+### SELinux
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Audit log | `/var/log/audit/audit.log` | SELinux denials |
+| SELinux booleans | `getsebool -a` output | Policy tuning |
+| SELinux status | `sestatus` output | SELinux state |
+
+### Systemd
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Journal export | `journalctl` output | Comprehensive logs |
+| Failed units | `systemctl --failed` | Service failures |
+| networkctl status | `networkctl` output | systemd-networkd state |
+
+### Kubernetes/AKS
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| CNI configuration | `/etc/cni/net.d/*` | Container networking |
+| Azure CNI logs | `/var/log/azure-cni*.log` | Azure CNI issues |
+| kube-proxy logs | `/var/log/kube-proxy.log` | Service proxy issues |
+| crictl info | `crictl info` output | Container runtime state |
+
+### Azure/Cloud
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Azure Arc agent | `/var/lib/GuestConfig/*` | Arc diagnostics |
+| Azure Monitor Agent | `/var/opt/microsoft/azuremonitoragent/*` | AMA diagnostics |
+| Accelerated Networking | `/var/log/azure/Microsoft.Azure.Networking.LinuxAgent/*` | AN driver issues |

--- a/docs/manifests/linux/diagnostic-modular.md
+++ b/docs/manifests/linux/diagnostic-modular.md
@@ -1,0 +1,400 @@
+# Linux Diagnostic Manifests - Modular Reference
+
+This document provides an overview of modular Linux diagnostic manifests for the Azure Disk Inspect Service. For detailed documentation on each area, see the specific docs linked below.
+
+## Documentation by Area
+
+| Area | Document | Description |
+|------|----------|-------------|
+| Azure Agent | [diagnostic-azure-agent.md](diagnostic-azure-agent.md) | waagent, ProxyAgent, Managed Identity |
+| Azure Extensions | [diagnostic-extensions.md](diagnostic-extensions.md) | Extension handler, AMA, LAD, SQL, etc. |
+| Azure Files | [diagnostic-azure-files.md](diagnostic-azure-files.md) | Cloud-init, Blobfuse |
+| Network | [diagnostic-network.md](diagnostic-network.md) | DHCP, DNS, SSH, Firewall, netconfig |
+| System Config | [diagnostic-sysconfig.md](diagnostic-sysconfig.md) | fstab, PAM, sudoers, boot, kernel |
+| System Logs | [diagnostic-syslogs.md](diagnostic-syslogs.md) | syslog, authlog, kernlog, sosreport |
+| Packages | [diagnostic-packages.md](diagnostic-packages.md) | APT, YUM, Zypper, TDNF, repos |
+| Kubernetes | [diagnostic-kubernetes.md](diagnostic-kubernetes.md) | kubelet, AKS, pods, CNI |
+| HPC | [diagnostic-hpc.md](diagnostic-hpc.md) | InfiniBand, Slurm, PBS, NVIDIA |
+
+## Naming Convention
+
+**Format:** `diagnostic-<section>-<distro|common>`
+
+- Section-first enables grouping by problem domain
+- `-common` suffix = works on all distros
+- `-<distro>` suffix = distro-specific (ubuntu, redhat, suse, mariner)
+- AI selects based on issue type, then distro if needed
+
+---
+
+## Quick Reference - All Manifests
+
+### Probing (Directory Listings)
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-probing-ubuntu` | Ubuntu/Debian | APT dirs, systemd | None |
+| `diagnostic-probing-redhat` | RHEL/CentOS/Fedora | YUM repos, systemd | None |
+| `diagnostic-probing-suse` | SLES/openSUSE | Zypp repos, systemd | None |
+| `diagnostic-probing-mariner` | Azure Linux | TDNF, systemd | None |
+| `diagnostic-probing-aks` | AKS nodes | pods, containers, k8s dirs | None |
+
+### DHCP
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-dhcp-ubuntu` | Ubuntu/Debian | dhclient, dhcp, NM leases | Low |
+| `diagnostic-dhcp-redhat` | RHEL/CentOS/Fedora | dhclient, NM leases | Low |
+| `diagnostic-dhcp-suse` | SLES/openSUSE | Wicked, NM leases | Low |
+| `diagnostic-dhcp-mariner` | Azure Linux | systemd-networkd, NM leases | Low |
+
+### Network Configuration
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-netconfig-ubuntu` | Ubuntu/Debian | netplan, interfaces | None |
+| `diagnostic-netconfig-redhat` | RHEL/CentOS/Fedora | sysconfig/network-scripts | None |
+| `diagnostic-netconfig-suse` | SLES/openSUSE | wicked, sysconfig | None |
+| `diagnostic-netconfig-mariner` | Azure Linux | systemd-networkd | None |
+| `diagnostic-networking-aks` | AKS nodes | CNI, VNET, IPAM, CNS, NPM | None |
+
+### NetworkManager
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-networkmanager-common` | All | NM config files | None |
+
+### DNS/Name Resolution
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-dns-common` | All | resolv.conf, nsswitch, hosts | Low |
+
+### SSH
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-ssh-common` | All | sshd_config, ssh_config | None |
+
+### PAM (Pluggable Auth)
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-pam-common` | All | pam.d, limits.conf | Low |
+
+### Firewall
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-firewall-ubuntu` | Ubuntu/Debian | UFW rules | None |
+| `diagnostic-firewall-redhat` | RHEL/CentOS/Fedora | firewalld, iptables | None |
+| `diagnostic-firewall-suse` | SLES/openSUSE | SuSEfirewall2, firewalld | None |
+| `diagnostic-firewall-mariner` | Azure Linux | nftables, firewalld | None |
+
+### Package Management Logs
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-packages-ubuntu` | Ubuntu/Debian | dpkg, APT logs | None |
+| `diagnostic-packages-redhat` | RHEL/CentOS/Fedora | YUM, DNF, RHSM, RHUI | Low |
+| `diagnostic-packages-suse` | SLES/openSUSE | Zypper logs | None |
+| `diagnostic-packages-mariner` | Azure Linux | TDNF, DNF logs | None |
+
+### Repository Configuration
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-repoconfig-ubuntu` | Ubuntu/Debian | sources.list | None |
+| `diagnostic-repoconfig-redhat` | RHEL/CentOS/Fedora | yum.repos.d | None |
+| `diagnostic-repoconfig-suse` | SLES/openSUSE | zypp repos | None |
+| `diagnostic-repoconfig-mariner` | Azure Linux | tdnf repos | None |
+
+### System Logs
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-syslog-common` | All | syslog, messages | Low |
+| `diagnostic-authlog-common` | All | auth.log, secure, wtmp | **High** |
+| `diagnostic-kernlog-common` | All | kern.log, dmesg | None |
+| `diagnostic-bootlog-common` | All | boot.log | None |
+| `diagnostic-clusterlog-common` | All | pacemaker, corosync | Low |
+| `diagnostic-cloudregister-suse` | SLES/openSUSE | cloudregister log | None |
+
+### System Configuration
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-fstab-common` | All | fstab, crypttab | None |
+| `diagnostic-sudoers-common` | All | sudoers, sudoers.d | **Medium** |
+| `diagnostic-sysctl-common` | All | sysctl.conf | None |
+| `diagnostic-udev-common` | All | udev rules, modprobe | None |
+| `diagnostic-release-common` | All | os-release, hostname | Low |
+| `diagnostic-time-common` | All | chrony, ntp, timezone | None |
+| `diagnostic-nfs-common` | All | NFS/idmapd config | None |
+
+### Security (MAC)
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-security-ubuntu` | Ubuntu/Debian | AppArmor | None |
+| `diagnostic-security-redhat` | RHEL/CentOS/Fedora | SELinux | None |
+| `diagnostic-security-suse` | SLES/openSUSE | AppArmor | None |
+| `diagnostic-security-mariner` | Azure Linux | SELinux | None |
+
+### Boot Configuration
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-bootconfig-common` | All | GRUB config | None |
+
+### Disk Info
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-diskinfo-common` | All | Partition layout | None |
+
+### Kubernetes/Containers
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-kubernetes-common` | All | kubelet, containerd, pods | Medium |
+| `diagnostic-kubernetes-aks` | AKS nodes | kubelet-status, containerd-status, journal | Medium |
+| `diagnostic-provision-aks` | AKS nodes | cluster-provision, CSE output | Low |
+| `diagnostic-pods-aks` | AKS nodes | kube-system, calico, tigera pods | Medium |
+
+### HPC
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-hpc-common` | All | InfiniBand, Slurm, PBS | Medium |
+
+### SOS/Support Reports
+| Manifest | Scope | Description | PII |
+|----------|-------|-------------|-----|
+| `diagnostic-sosreport-common` | RHEL/Ubuntu | sosreport tarballs | **High** |
+| `diagnostic-supportconfig-suse` | SLES/openSUSE | supportconfig tarballs | **High** |
+
+---
+
+## Selection by Issue Type
+
+### SSH Access Issues
+```
+diagnostic-ssh-common
+diagnostic-pam-common
+diagnostic-authlog-common
+diagnostic-firewall-<distro>
+```
+
+### DNS/Name Resolution Issues
+```
+diagnostic-dns-common
+diagnostic-netconfig-<distro>
+diagnostic-networkmanager-common
+```
+
+### Network Connectivity Issues
+```
+diagnostic-probing-<distro>
+diagnostic-dhcp-<distro>
+diagnostic-netconfig-<distro>
+diagnostic-networkmanager-common
+diagnostic-firewall-<distro>
+```
+
+### Boot/Startup Issues
+```
+diagnostic-bootconfig-common
+diagnostic-bootlog-common
+diagnostic-kernlog-common
+diagnostic-fstab-common
+diagnostic-diskinfo-common
+```
+
+### Kernel/Driver Issues
+```
+diagnostic-kernlog-common
+diagnostic-udev-common
+diagnostic-sysctl-common
+```
+
+### Package Installation Issues
+```
+diagnostic-packages-<distro>
+diagnostic-repoconfig-<distro>
+diagnostic-syslog-common
+```
+
+### Disk/Mount Issues
+```
+diagnostic-diskinfo-common
+diagnostic-fstab-common
+diagnostic-kernlog-common
+diagnostic-syslog-common
+```
+
+### Authentication/Login Issues
+```
+diagnostic-authlog-common
+diagnostic-pam-common
+diagnostic-sudoers-common
+diagnostic-ssh-common
+```
+
+### Firewall/Connectivity Blocked
+```
+diagnostic-firewall-<distro>
+diagnostic-security-<distro>
+diagnostic-syslog-common
+```
+
+### Time/NTP Issues
+```
+diagnostic-time-common
+diagnostic-syslog-common
+```
+
+### Cluster (HA) Issues
+```
+diagnostic-clusterlog-common
+diagnostic-fstab-common
+diagnostic-netconfig-<distro>
+```
+
+### Kubernetes Issues
+```
+diagnostic-kubernetes-common
+diagnostic-syslog-common
+diagnostic-netconfig-<distro>
+```
+
+### AKS Issues
+```
+diagnostic-probing-aks
+diagnostic-provision-aks
+diagnostic-kubernetes-aks
+diagnostic-pods-aks
+diagnostic-networking-aks
+```
+
+### HPC/GPU Issues
+```
+diagnostic-hpc-common
+diagnostic-kernlog-common
+diagnostic-udev-common
+```
+
+---
+
+## PII Risk Summary
+
+| Risk Level | Manifests |
+|------------|-----------|
+| **High** | authlog-common, sosreport-common, supportconfig-suse |
+| **Medium** | sudoers-common, kubernetes-common, hpc-common |
+| **Low** | dns-common, dhcp-*, packages-redhat, syslog-common, release-common, pam-common, clusterlog-common |
+| **None** | All others |
+
+---
+
+## Azure-Specific Manifests
+
+See detailed docs: [diagnostic-azure-agent.md](diagnostic-azure-agent.md) | [diagnostic-extensions.md](diagnostic-extensions.md) | [diagnostic-azure-files.md](diagnostic-azure-files.md)
+
+### Azure Agent
+| Manifest | Description | PII |
+|----------|-------------|-----|
+| `diagnostic-azure-agent-probing` | Directory listings for waagent | None |
+| `diagnostic-azure-agent-config` | waagent.conf | None |
+| `diagnostic-azure-agent-logs` | waagent logs | Low |
+| `diagnostic-azure-agent-state` | Agent state, status, incarnation | None |
+| `diagnostic-azure-agent-xml` | SharedConfig, GoalState, ExtensionsConfig | Low |
+| `diagnostic-azure-agent-identity` | ManagedIdentity JSON files | **Medium** |
+| `diagnostic-azure-agent-proxyagent` | Guest ProxyAgent logs | Low |
+
+### Azure Extensions
+| Manifest | Description | PII |
+|----------|-------------|-----|
+| `diagnostic-extensions-probing` | Directory listings for extensions | None |
+| `diagnostic-extensions-handler` | Handler config, state, status | Low |
+| `diagnostic-extensions-logs` | Extension log files /var/log/azure | Low |
+| `diagnostic-extensions-monitoring` | Azure Monitor Agent - AMA | Low |
+| `diagnostic-extensions-lad` | Linux Diagnostic Extension | Low |
+| `diagnostic-extensions-siterecovery` | Site Recovery Extension | Low |
+| `diagnostic-extensions-sqliaas` | SQL IaaS Extension | Low |
+| `diagnostic-extensions-workloadbackup` | Workload Backup - SAP HANA | Low |
+| `diagnostic-extensions-servicefabric` | Service Fabric and Key Vault | Low |
+
+### Azure Files
+| Manifest | Description | PII |
+|----------|-------------|-----|
+| `diagnostic-cloudinit-common` | Cloud-init provisioning | Low |
+| `diagnostic-blobfuse-common` | Blobfuse mount logs | None |
+
+### Azure Agent Issues
+```
+diagnostic-azure-agent-probing
+diagnostic-azure-agent-config
+diagnostic-azure-agent-logs
+diagnostic-azure-agent-state
+diagnostic-azure-agent-xml
+```
+
+### Managed Identity Issues
+```
+diagnostic-azure-agent-identity
+diagnostic-azure-agent-logs
+diagnostic-azure-agent-state
+```
+
+### ProxyAgent Issues
+```
+diagnostic-azure-agent-proxyagent
+diagnostic-azure-agent-logs
+```
+
+### Extension Handler Issues
+```
+diagnostic-extensions-probing
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Azure Monitor Agent Issues
+```
+diagnostic-extensions-monitoring
+diagnostic-extensions-probing
+diagnostic-extensions-logs
+```
+
+### Linux Diagnostic Extension Issues
+```
+diagnostic-extensions-lad
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Site Recovery Issues
+```
+diagnostic-extensions-siterecovery
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### SQL IaaS Issues
+```
+diagnostic-extensions-sqliaas
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Workload Backup Issues
+```
+diagnostic-extensions-workloadbackup
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+### Service Fabric Issues
+```
+diagnostic-extensions-servicefabric
+diagnostic-extensions-handler
+diagnostic-extensions-logs
+```
+
+---
+
+## Estimated Sizes
+
+| Category | Size Range |
+|----------|------------|
+| Probing/Listings | < 100 KB |
+| Config files | < 100 KB each |
+| Package logs | 100 KB - 5 MB |
+| System logs | 1 - 50 MB each |
+| Auth logs | 1 - 20 MB |
+| Kubernetes logs | 5 - 50 MB |
+| SOS/Supportconfig | 10 - 500 MB |

--- a/docs/manifests/linux/diagnostic-network.md
+++ b/docs/manifests/linux/diagnostic-network.md
@@ -1,0 +1,87 @@
+# Network Diagnostic Manifests
+
+Modular manifests for network configuration and troubleshooting.
+
+## Available Manifests
+
+### Network Configuration - Distro Specific
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-netconfig-ubuntu` | Ubuntu/Debian | netplan, interfaces | None |
+| `diagnostic-netconfig-redhat` | RHEL/CentOS/Fedora | sysconfig/network-scripts | None |
+| `diagnostic-netconfig-suse` | SLES/openSUSE | wicked, sysconfig | None |
+| `diagnostic-netconfig-mariner` | Azure Linux | systemd-networkd | None |
+
+### NetworkManager
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-networkmanager-common` | All | NM config and state files | None |
+
+### DHCP - Distro Specific
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-dhcp-ubuntu` | Ubuntu/Debian | dhclient, dhcp, NM leases | Low |
+| `diagnostic-dhcp-redhat` | RHEL/CentOS/Fedora | dhclient, NM leases | Low |
+| `diagnostic-dhcp-suse` | SLES/openSUSE | Wicked, NM leases | Low |
+| `diagnostic-dhcp-mariner` | Azure Linux | systemd-networkd, NM leases | Low |
+
+### DNS
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-dns-common` | All | resolv.conf, nsswitch, hosts | Low |
+
+### SSH
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-ssh-common` | All | sshd_config, ssh_config | None |
+
+### Firewall - Distro Specific
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-firewall-ubuntu` | Ubuntu/Debian | UFW rules | None |
+| `diagnostic-firewall-redhat` | RHEL/CentOS/Fedora | firewalld, iptables | None |
+| `diagnostic-firewall-suse` | SLES/openSUSE | SuSEfirewall2, firewalld | None |
+| `diagnostic-firewall-mariner` | Azure Linux | nftables, firewalld | None |
+
+## Issue Type Selection
+
+### Network Connectivity Issues
+```
+diagnostic-probing-<distro>
+diagnostic-dhcp-<distro>
+diagnostic-netconfig-<distro>
+diagnostic-networkmanager-common
+diagnostic-firewall-<distro>
+diagnostic-syslog-common
+```
+
+### DNS Resolution Issues
+```
+diagnostic-dns-common
+diagnostic-netconfig-<distro>
+diagnostic-networkmanager-common
+diagnostic-syslog-common
+```
+
+### SSH Access Issues
+```
+diagnostic-ssh-common
+diagnostic-pam-common
+diagnostic-authlog-common
+diagnostic-firewall-<distro>
+```
+
+### DHCP Issues
+```
+diagnostic-dhcp-<distro>
+diagnostic-networkmanager-common
+diagnostic-syslog-common
+```
+
+### Firewall Blocking Issues
+```
+diagnostic-firewall-<distro>
+diagnostic-security-<distro>
+diagnostic-syslog-common
+```
+

--- a/docs/manifests/linux/diagnostic-packages.md
+++ b/docs/manifests/linux/diagnostic-packages.md
@@ -1,0 +1,64 @@
+# Package Management Diagnostic Manifests
+
+Modular manifests for package management troubleshooting.
+
+## Package Logs - Distro Specific
+
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-packages-ubuntu` | Ubuntu/Debian | dpkg, APT, unattended-upgrades | None |
+| `diagnostic-packages-redhat` | RHEL/CentOS/Fedora | YUM, DNF, RHSM, RHUI | Low |
+| `diagnostic-packages-suse` | SLES/openSUSE | Zypper logs | None |
+| `diagnostic-packages-mariner` | Azure Linux | TDNF, DNF logs | None |
+
+## Repository Configuration - Distro Specific
+
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-repoconfig-ubuntu` | Ubuntu/Debian | sources.list | None |
+| `diagnostic-repoconfig-redhat` | RHEL/CentOS/Fedora | yum.repos.d | None |
+| `diagnostic-repoconfig-suse` | SLES/openSUSE | zypp repos | None |
+| `diagnostic-repoconfig-mariner` | Azure Linux | tdnf repos | None |
+
+## Issue Type Selection
+
+### Package Installation Issues
+```
+diagnostic-packages-<distro>
+diagnostic-repoconfig-<distro>
+diagnostic-syslog-common
+```
+
+### Repository Access Issues
+```
+diagnostic-repoconfig-<distro>
+diagnostic-dns-common
+diagnostic-netconfig-<distro>
+diagnostic-syslog-common
+```
+
+### RHEL Subscription Issues
+```
+diagnostic-packages-redhat
+diagnostic-repoconfig-redhat
+diagnostic-syslog-common
+```
+
+### SUSE Registration Issues
+```
+diagnostic-packages-suse
+diagnostic-repoconfig-suse
+diagnostic-cloudregister-suse
+diagnostic-syslog-common
+```
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-packages-ubuntu | 100 KB - 2 MB |
+| diagnostic-packages-redhat | 100 KB - 5 MB |
+| diagnostic-packages-suse | 100 KB - 1 MB |
+| diagnostic-packages-mariner | 100 KB - 1 MB |
+| diagnostic-repoconfig-* | < 100 KB |
+

--- a/docs/manifests/linux/diagnostic-redhat.md
+++ b/docs/manifests/linux/diagnostic-redhat.md
@@ -1,0 +1,208 @@
+# Azure Disk Inspect: diagnostic-redhat Manifest
+
+This document describes the `diagnostic-redhat` manifest used by the Azure Disk Inspect Service (IID/Ghostfish) to collect diagnostic files from RHEL, CentOS, Fedora, and other Red Hat-based Azure VMs.
+
+**Note:** For Azure Agent and extension issues, use the `azure-agent` and `azure-extensions` manifests alongside this one.
+
+## Summary
+
+| Section | File Count (Est.) | Size (Est.) | Notes |
+|---------|-------------------|-------------|-------|
+| Probing Directories | 14 listings | Minimal | Directory listings only |
+| DHCP Files | 4-8 files | < 50 KB | NetworkManager/dhclient leases |
+| Networking Files | 10-15 files | < 200 KB | ssh, hosts, pam |
+| NetworkManager Files | 5-15 files | < 100 KB | NM configuration |
+| Sysconfig Network | 10-20 files | < 200 KB | ifcfg, routes, firewalld |
+| Package Management | 10-30 files | 500 KB - 5 MB | yum, dnf, rhsm |
+| System Log Files | 15-30 files | 10-100 MB | messages, secure, kern |
+| System Configuration | 15-30 files | < 500 KB | fstab, SELinux, sudoers |
+| Disk Info | 1 item | < 100 KB | Disk partition layout |
+| RHUI | 2-5 files | < 1 MB | Red Hat Update Infrastructure |
+
+**Total Estimated Size:** 15-130 MB depending on log retention
+
+---
+
+## Section Details
+
+### 1. Probing Directories (14 items)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/boot` | Kernel and boot files | |
+| `/var/log` | Log directory structure | |
+| `/var/lib/cloud` | Cloud-init state | |
+| `/var/lib/waagent` | Azure Agent state | |
+| `/etc` | Configuration overview | |
+| `/etc/udev/rules.d` | Device rules | |
+| `/etc/alternatives` | System alternatives | |
+| `/etc/systemd/system` | Custom systemd units | |
+| `/etc/systemd/system/multi-user.target.wants` | Multi-user services | |
+| `/etc/systemd/system/graphical.target.wants` | Graphical services | |
+| `/etc/systemd/user` | User systemd units | |
+| `/etc/yum.repos.d` | YUM/DNF repository configs | |
+| `/usr/lib/systemd/system` | Vendor systemd units | |
+| `/usr/lib/systemd/user` | Vendor user units | |
+
+### 2. DHCP Files (4-8 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/lib/NetworkManager/*.lease` | NetworkManager leases | |
+| `/var/lib/NetworkManager/*.leases` | NM leases (alternate) | |
+| `/var/lib/dhclient/*.lease` | dhclient leases | |
+| `/var/lib/dhclient/*.leases` | dhclient leases (alternate) | |
+
+### 3. Networking Files (10-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/dhcp/*.conf` | DHCP client config | |
+| `/etc/ssh/sshd_config` | SSH daemon config | |
+| `/etc/ssh/sshd_config.d/*` | SSH config includes | |
+| `/etc/nsswitch.conf` | Name service switch | |
+| `/etc/resolv.conf` | DNS resolver config | |
+| `/etc/hosts` | Static host mappings | X |
+| `/etc/hosts.allow` | TCP wrappers allow | |
+| `/etc/hosts.deny` | TCP wrappers deny | |
+| `/etc/pam.d/*` | PAM configuration | X |
+
+### 4. NetworkManager Files (5-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/usr/lib/NetworkManager/*.conf` | Vendor NM config | |
+| `/usr/lib/NetworkManager/conf.d/*.conf` | Vendor NM includes | |
+| `/etc/NetworkManager/*.conf` | System NM config | |
+| `/etc/NetworkManager/conf.d/*.conf` | System NM includes | |
+| `/var/lib/NetworkManager/*.conf` | Runtime NM config | |
+| `/var/lib/NetworkManager/conf.d/*.conf` | Runtime NM includes | |
+| `/var/lib/NetworkManager/*.state` | NM state files | |
+
+### 5. Sysconfig Network Files (10-20 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/sysconfig/network` | Global network settings | |
+| `/etc/sysconfig/network-scripts/ifcfg-*` | Interface configuration | |
+| `/etc/sysconfig/network-scripts/route-*` | Static routes | |
+| `/etc/sysconfig/iptables` | iptables rules | |
+| `/etc/firewalld/*.xml` | firewalld config | |
+| `/etc/firewalld/zones/*.xml` | firewalld zones | |
+
+### 6. Package Management Log Files (10-30 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/yum*` | YUM package logs | |
+| `/var/log/dnf*` | DNF package logs | |
+| `/var/log/rhsm/*` | Red Hat Subscription Manager | X |
+
+### 7. System Log Files (15-30 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/messages*` | System messages | |
+| `/var/log/syslog*` | Syslog (fallback) | |
+| `/var/log/rsyslog*` | Rsyslog output | |
+| `/var/log/kern*` | Kernel messages | |
+| `/var/log/dmesg*` | Boot ring buffer | |
+| `/var/log/boot*` | Boot logs | |
+| `/var/log/auth*` | Authentication log (fallback) | X |
+| `/var/log/secure*` | Secure log | X |
+| `/var/log/pacemaker*` | Pacemaker cluster | |
+| `/var/log/corosync*` | Corosync cluster | |
+| `/var/log/cluster/*` | Cluster logs | |
+| `/var/log/pacemaker/*` | Pacemaker directory | |
+| `/var/log/corosync/*` | Corosync directory | |
+
+### 8. System Configuration Files (15-30 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/fstab` | Filesystem mounts | |
+| `/etc/crypttab` | Encrypted volumes | X |
+| `/etc/*-release` | OS release info | |
+| `/etc/HOSTNAME` | Hostname (legacy) | |
+| `/etc/hostname` | Hostname | |
+| `/etc/localtime` | Timezone symlink | |
+| `/etc/chrony/chrony.conf` | Chrony NTP config | |
+| `/etc/idmapd.conf` | NFSv4 ID mapping | |
+| `/etc/sudoers` | Sudo configuration | X |
+| `/etc/sudoers.d/*` | Sudo includes | X |
+| `/etc/sysctl.conf` | Kernel parameters | |
+| `/etc/sysctl.d/*.conf` | Sysctl includes | |
+| `/etc/udev/rules.d/*.rules` | Device rules | |
+| `/etc/modprobe.d/*.conf` | Kernel module config | |
+| `/etc/security/limits.conf` | Resource limits | |
+| `/etc/selinux/config` | SELinux configuration | |
+| `/etc/sysconfig/selinux` | SELinux sysconfig | |
+
+### 9. Disk Info (1 item)
+
+| Command | Purpose | X |
+|---------|---------|---|
+| `diskinfo,` | Disk partition info | |
+
+### 10. Red Hat Update Infrastructure (2-5 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/rhuicheck.log` | RHUI health check | |
+| `/var/log/rhui/*` | RHUI logs | |
+
+---
+
+## Legend
+
+**X Column:** Items marked with X may contain sensitive or personally identifiable information (PII):
+- Authentication logs with usernames
+- Subscription/entitlement information
+- Sudo user configurations
+- Encrypted volume information
+
+---
+
+## Potentially Missing Items
+
+### Boot and Kernel
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| GRUB2 configuration | `/boot/grub2/grub.cfg`, `/etc/default/grub` | Boot parameter issues |
+| Kernel crash dumps | `/var/crash/*` | Kernel panic analysis |
+| dracut logs | `/var/log/dracut.log` | initramfs issues |
+
+### YUM/DNF
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| YUM repo files | `/etc/yum.repos.d/*.repo` | Repository configuration |
+| DNF modules | `/etc/dnf/modules.d/*` | Module streams |
+| RPM database | `/var/lib/rpm/*` (metadata) | Package integrity |
+
+### SELinux
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Audit log | `/var/log/audit/audit.log` | SELinux denials |
+| SELinux booleans | `getsebool -a` output | Policy tuning |
+| SELinux contexts | `/etc/selinux/*/contexts/*` | Context configuration |
+
+### Systemd
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Journal export | `journalctl` output | Comprehensive logs |
+| Failed units | `systemctl --failed` | Service failures |
+| Service overrides | `/etc/systemd/system/*.d/*.conf` | Custom settings |
+
+### Network
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| nmcli output | `nmcli connection show` | Connection details |
+| firewall-cmd output | `firewall-cmd --list-all` | Active firewall rules |
+| Network scripts (RHEL 8+) | `/etc/NetworkManager/system-connections/*` | NM keyfiles |
+
+### Subscription
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| RHSM identity | `/etc/pki/consumer/cert.pem` | Subscription cert |
+| RHSM config | `/etc/rhsm/rhsm.conf` | Subscription settings |
+| Entitlements | `/etc/pki/entitlement/*` | Product entitlements |

--- a/docs/manifests/linux/diagnostic-suse.md
+++ b/docs/manifests/linux/diagnostic-suse.md
@@ -1,0 +1,212 @@
+# Azure Disk Inspect: diagnostic-suse Manifest
+
+This document describes the `diagnostic-suse` manifest used by the Azure Disk Inspect Service (IID/Ghostfish) to collect diagnostic files from SUSE Linux Enterprise Server (SLES) and openSUSE Azure VMs.
+
+**Note:** For Azure Agent and extension issues, use the `azure-agent` and `azure-extensions` manifests alongside this one.
+
+## Summary
+
+| Section | File Count (Est.) | Size (Est.) | Notes |
+|---------|-------------------|-------------|-------|
+| Probing Directories | 14 listings | Minimal | Directory listings only |
+| DHCP Files (Wicked) | 3-6 files | < 50 KB | Wicked and NM leases |
+| Networking Files | 10-15 files | < 200 KB | ssh, hosts, pam |
+| NetworkManager Files | 5-15 files | < 100 KB | NM configuration |
+| Sysconfig Network | 10-15 files | < 200 KB | ifcfg, routes, SuSEfirewall2 |
+| Wicked Network | 5-10 files | < 100 KB | Wicked XML config |
+| Package Management | 2-5 files | 100 KB - 1 MB | zypper, zypp |
+| System Log Files | 15-30 files | 10-100 MB | messages, secure, cloudregister |
+| System Configuration | 15-25 files | < 500 KB | fstab, AppArmor, sudoers |
+| Disk Info | 1 item | < 100 KB | Disk partition layout |
+
+**Total Estimated Size:** 15-125 MB depending on log retention
+
+---
+
+## Section Details
+
+### 1. Probing Directories (14 items)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/boot` | Kernel and boot files | |
+| `/var/log` | Log directory structure | |
+| `/var/lib/cloud` | Cloud-init state | |
+| `/var/lib/waagent` | Azure Agent state | |
+| `/etc` | Configuration overview | |
+| `/etc/udev/rules.d` | Device rules | |
+| `/etc/alternatives` | System alternatives | |
+| `/etc/systemd/system` | Custom systemd units | |
+| `/etc/systemd/system/multi-user.target.wants` | Multi-user services | |
+| `/etc/systemd/system/graphical.target.wants` | Graphical services | |
+| `/etc/systemd/user` | User systemd units | |
+| `/etc/zypp/repos.d` | Zypper repository configs | |
+| `/usr/lib/systemd/system` | Vendor systemd units | |
+| `/usr/lib/systemd/user` | Vendor user units | |
+
+### 2. DHCP Files - Wicked (3-6 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/lib/wicked/lease*` | Wicked DHCP leases | |
+| `/var/lib/NetworkManager/*.lease` | NetworkManager leases | |
+| `/var/lib/NetworkManager/*.leases` | NM leases (alternate) | |
+
+### 3. Networking Files (10-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/dhcp/*.conf` | DHCP client config | |
+| `/etc/ssh/sshd_config` | SSH daemon config | |
+| `/etc/ssh/sshd_config.d/*` | SSH config includes | |
+| `/etc/nsswitch.conf` | Name service switch | |
+| `/etc/resolv.conf` | DNS resolver config | |
+| `/etc/hosts` | Static host mappings | X |
+| `/etc/hosts.allow` | TCP wrappers allow | |
+| `/etc/hosts.deny` | TCP wrappers deny | |
+| `/etc/pam.d/*` | PAM configuration | X |
+
+### 4. NetworkManager Files (5-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/usr/lib/NetworkManager/*.conf` | Vendor NM config | |
+| `/usr/lib/NetworkManager/conf.d/*.conf` | Vendor NM includes | |
+| `/etc/NetworkManager/*.conf` | System NM config | |
+| `/etc/NetworkManager/conf.d/*.conf` | System NM includes | |
+| `/var/lib/NetworkManager/*.conf` | Runtime NM config | |
+| `/var/lib/NetworkManager/conf.d/*.conf` | Runtime NM includes | |
+| `/var/lib/NetworkManager/*.state` | NM state files | |
+
+### 5. Sysconfig Network Files - SUSE (10-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/sysconfig/network` | Global network settings | |
+| `/etc/sysconfig/network/ifcfg-*` | Interface configuration | |
+| `/etc/sysconfig/network/routes` | Global static routes | |
+| `/etc/sysconfig/network/ifroute-*` | Per-interface routes | |
+| `/etc/sysconfig/SuSEfirewall2` | SuSEfirewall2 config | |
+| `/etc/sysconfig/SuSEfirewall2.d/*` | SuSEfirewall2 includes | |
+
+### 6. Wicked Network Files - SUSE (5-10 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/wicked/*.xml` | Wicked configuration | |
+| `/etc/wicked/ifconfig/*.xml` | Wicked interface config | |
+
+### 7. Package Management Log Files - SUSE (2-5 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/zypp/history` | Zypper transaction history | |
+| `/var/log/zypper.log` | Zypper log | |
+
+### 8. System Log Files (15-30 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/messages*` | System messages | |
+| `/var/log/syslog*` | Syslog (fallback) | |
+| `/var/log/rsyslog*` | Rsyslog output | |
+| `/var/log/kern*` | Kernel messages | |
+| `/var/log/dmesg*` | Boot ring buffer | |
+| `/var/log/boot*` | Boot logs | |
+| `/var/log/auth*` | Authentication log (fallback) | X |
+| `/var/log/secure*` | Secure log | X |
+| `/var/log/cloudregister` | SUSE cloud registration | |
+| `/var/log/pacemaker*` | Pacemaker cluster | |
+| `/var/log/corosync*` | Corosync cluster | |
+| `/var/log/cluster/*` | Cluster logs | |
+| `/var/log/pacemaker/*` | Pacemaker directory | |
+| `/var/log/corosync/*` | Corosync directory | |
+
+### 9. System Configuration Files (15-25 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/fstab` | Filesystem mounts | |
+| `/etc/crypttab` | Encrypted volumes | X |
+| `/etc/*-release` | OS release info | |
+| `/etc/HOSTNAME` | Hostname (SUSE style) | |
+| `/etc/hostname` | Hostname (standard) | |
+| `/etc/localtime` | Timezone symlink | |
+| `/etc/chrony/chrony.conf` | Chrony NTP config | |
+| `/etc/idmapd.conf` | NFSv4 ID mapping | |
+| `/etc/sudoers` | Sudo configuration | X |
+| `/etc/sudoers.d/*` | Sudo includes | X |
+| `/etc/sysctl.conf` | Kernel parameters | |
+| `/etc/sysctl.d/*.conf` | Sysctl includes | |
+| `/etc/udev/rules.d/*.rules` | Device rules | |
+| `/etc/modprobe.d/*.conf` | Kernel module config | |
+| `/etc/security/limits.conf` | Resource limits | |
+| `/sys/kernel/security/apparmor/profiles` | AppArmor profiles | |
+
+### 10. Disk Info (1 item)
+
+| Command | Purpose | X |
+|---------|---------|---|
+| `diskinfo,` | Disk partition info | |
+
+---
+
+## Legend
+
+**X Column:** Items marked with X may contain sensitive or personally identifiable information (PII):
+- Authentication logs with usernames
+- Sudo user configurations
+- Host-specific network information
+- Encrypted volume information
+
+---
+
+## Potentially Missing Items
+
+### Boot and Kernel
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| GRUB2 configuration | `/boot/grub2/grub.cfg`, `/etc/default/grub` | Boot parameter issues |
+| Kernel crash dumps | `/var/crash/*` | Kernel panic analysis |
+| mkinitrd logs | `/var/log/YaST2/mkinitrd.log` | initrd issues |
+
+### Zypper/Package Management
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Zypper repos | `/etc/zypp/repos.d/*.repo` | Repository configuration |
+| Zypper services | `/etc/zypp/services.d/*` | Repository services |
+| RPM database | `/var/lib/rpm/*` (metadata) | Package integrity |
+| SUSEConnect | `/etc/SUSEConnect` | Registration config |
+
+### Wicked
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Wicked logs | `/var/log/wicked.log` | Network daemon logs |
+| Wicked state | `/var/run/wicked/*` | Runtime state |
+
+### AppArmor
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| AppArmor logs | `/var/log/audit/audit.log` | Policy denials |
+| AppArmor profiles | `/etc/apparmor.d/*` | Profile definitions |
+| aa-status output | `aa-status` | AppArmor state |
+
+### Systemd
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Journal export | `journalctl` output | Comprehensive logs |
+| Failed units | `systemctl --failed` | Service failures |
+| Service overrides | `/etc/systemd/system/*.d/*.conf` | Custom settings |
+
+### SUSE Cloud
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| registercloudguest | `/var/log/registercloudguest` | Cloud registration |
+| SUSEConnect log | `/var/log/SUSEConnect.log` | Registration log |
+| SMT/RMT config | `/etc/SUSEConnect` | Update server config |
+
+### YaST
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| YaST logs | `/var/log/YaST2/*` | YaST operations |
+| AutoYaST profile | `/root/autoinst.xml` | AutoYaST config |

--- a/docs/manifests/linux/diagnostic-sysconfig.md
+++ b/docs/manifests/linux/diagnostic-sysconfig.md
@@ -1,0 +1,87 @@
+# System Configuration Diagnostic Manifests
+
+Modular manifests for system configuration troubleshooting.
+
+## Available Manifests
+
+### Filesystem and Storage
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-fstab-common` | fstab, crypttab, mdadm | None |
+| `diagnostic-diskinfo-common` | Disk partition layout | None |
+| `diagnostic-nfs-common` | NFS and idmapd config | None |
+
+### Security and Authentication
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-pam-common` | All | PAM configuration, limits.conf | Low |
+| `diagnostic-sudoers-common` | All | sudoers configuration | **Medium** |
+| `diagnostic-authlog-common` | All | auth.log, secure, wtmp, btmp | **High** |
+| `diagnostic-security-ubuntu` | Ubuntu/Debian | AppArmor | None |
+| `diagnostic-security-redhat` | RHEL/CentOS/Fedora | SELinux | None |
+| `diagnostic-security-suse` | SLES/openSUSE | AppArmor | None |
+| `diagnostic-security-mariner` | Azure Linux | SELinux | None |
+
+### Kernel and Boot
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-bootconfig-common` | GRUB configuration | None |
+| `diagnostic-bootlog-common` | Boot logs | None |
+| `diagnostic-kernlog-common` | Kernel logs, dmesg | None |
+| `diagnostic-sysctl-common` | Sysctl configuration | None |
+| `diagnostic-udev-common` | Udev rules, modprobe | None |
+
+### System Identity
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-release-common` | OS release, hostname, machine-id | Low |
+| `diagnostic-time-common` | Chrony, NTP, timezone | None |
+
+## Issue Type Selection
+
+### Boot Issues
+```
+diagnostic-bootconfig-common
+diagnostic-bootlog-common
+diagnostic-kernlog-common
+diagnostic-fstab-common
+diagnostic-diskinfo-common
+```
+
+### Disk Mount Issues
+```
+diagnostic-fstab-common
+diagnostic-diskinfo-common
+diagnostic-kernlog-common
+diagnostic-syslog-common
+```
+
+### Authentication Issues
+```
+diagnostic-authlog-common
+diagnostic-pam-common
+diagnostic-sudoers-common
+diagnostic-ssh-common
+```
+
+### Kernel Driver Issues
+```
+diagnostic-kernlog-common
+diagnostic-udev-common
+diagnostic-sysctl-common
+diagnostic-bootlog-common
+```
+
+### Time Sync Issues
+```
+diagnostic-time-common
+diagnostic-syslog-common
+```
+
+### Security Policy Issues
+```
+diagnostic-security-<distro>
+diagnostic-authlog-common
+diagnostic-syslog-common
+```
+

--- a/docs/manifests/linux/diagnostic-syslogs.md
+++ b/docs/manifests/linux/diagnostic-syslogs.md
@@ -1,0 +1,88 @@
+# System Logs Diagnostic Manifests
+
+Modular manifests for system log collection.
+
+## Available Manifests
+
+| Manifest | Description | PII Risk |
+|----------|-------------|----------|
+| `diagnostic-syslog-common` | syslog, messages | Low |
+| `diagnostic-authlog-common` | auth.log, secure, wtmp, btmp | **High** |
+| `diagnostic-kernlog-common` | kern.log, dmesg | None |
+| `diagnostic-bootlog-common` | boot.log | None |
+| `diagnostic-clusterlog-common` | Pacemaker, Corosync cluster logs | Low |
+| `diagnostic-cloudregister-suse` | SUSE cloud registration log | None |
+
+## Probing Manifests - Distro Specific
+
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-probing-ubuntu` | Ubuntu/Debian | APT dirs, systemd | None |
+| `diagnostic-probing-redhat` | RHEL/CentOS/Fedora | YUM repos, systemd | None |
+| `diagnostic-probing-suse` | SLES/openSUSE | Zypp repos, systemd | None |
+| `diagnostic-probing-mariner` | Azure Linux | TDNF, systemd | None |
+
+## SOS Reports
+
+| Manifest | Scope | Description | PII Risk |
+|----------|-------|-------------|----------|
+| `diagnostic-sosreport-common` | RHEL/Ubuntu | sosreport tarballs | **High** |
+| `diagnostic-supportconfig-suse` | SLES/openSUSE | supportconfig tarballs | **High** |
+
+## Issue Type Selection
+
+### General System Issues
+```
+diagnostic-probing-<distro>
+diagnostic-syslog-common
+diagnostic-kernlog-common
+```
+
+### Boot Issues
+```
+diagnostic-bootlog-common
+diagnostic-kernlog-common
+diagnostic-syslog-common
+```
+
+### Kernel Panic or Crash
+```
+diagnostic-kernlog-common
+diagnostic-syslog-common
+diagnostic-bootlog-common
+```
+
+### Cluster HA Issues
+```
+diagnostic-clusterlog-common
+diagnostic-syslog-common
+diagnostic-fstab-common
+```
+
+### Full System Snapshot
+```
+diagnostic-sosreport-common   (RHEL/Ubuntu)
+diagnostic-supportconfig-suse (SUSE)
+```
+
+## PII Risk Summary
+
+| Risk Level | Manifests |
+|------------|-----------|
+| **High** | authlog-common, sosreport-common, supportconfig-suse |
+| **Medium** | sudoers-common |
+| **Low** | syslog-common, clusterlog-common |
+| **None** | All others |
+
+## Estimated Sizes
+
+| Manifest | Size Range |
+|----------|------------|
+| diagnostic-syslog-common | 1-50 MB |
+| diagnostic-authlog-common | 1-20 MB |
+| diagnostic-kernlog-common | 1-10 MB |
+| diagnostic-bootlog-common | < 1 MB |
+| diagnostic-clusterlog-common | 1-20 MB |
+| diagnostic-sosreport-common | 10-500 MB |
+| diagnostic-supportconfig-suse | 10-500 MB |
+

--- a/docs/manifests/linux/diagnostic-ubuntu.md
+++ b/docs/manifests/linux/diagnostic-ubuntu.md
@@ -1,0 +1,189 @@
+# Azure Disk Inspect: diagnostic-ubuntu Manifest
+
+This document describes the `diagnostic-ubuntu` manifest used by the Azure Disk Inspect Service (IID/Ghostfish) to collect diagnostic files from Ubuntu and Debian-based Azure VMs.
+
+**Note:** For Azure Agent and extension issues, use the `azure-agent` and `azure-extensions` manifests alongside this one.
+
+## Summary
+
+| Section | File Count (Est.) | Size (Est.) | Notes |
+|---------|-------------------|-------------|-------|
+| Probing Directories | 15 listings | Minimal | Directory listings only |
+| DHCP/Dhclient Files | 5-10 files | < 50 KB | DHCP leases |
+| Networking Files | 15-25 files | < 500 KB | netplan, ufw, ssh, hosts |
+| NetworkManager Files | 5-15 files | < 100 KB | NM configuration |
+| Package Management | 10-20 files | 500 KB - 2 MB | dpkg, apt, unattended-upgrades |
+| System Log Files | 15-30 files | 10-100 MB | syslog, auth, kern, dmesg |
+| System Configuration | 15-25 files | < 500 KB | fstab, sudoers, sysctl |
+| Disk Info | 1 item | < 100 KB | Disk partition layout |
+
+**Total Estimated Size:** 15-125 MB depending on log retention
+
+---
+
+## Section Details
+
+### 1. Probing Directories (15 items)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/boot` | Kernel and boot files | |
+| `/var/log` | Log directory structure | |
+| `/var/lib/cloud` | Cloud-init state | |
+| `/var/lib/waagent` | Azure Agent state | |
+| `/etc` | Configuration overview | |
+| `/etc/udev/rules.d` | Device rules | |
+| `/etc/alternatives` | System alternatives | |
+| `/etc/systemd/system` | Custom systemd units | |
+| `/etc/systemd/system/multi-user.target.wants` | Multi-user services | |
+| `/etc/systemd/system/graphical.target.wants` | Graphical services | |
+| `/etc/systemd/user` | User systemd units | |
+| `/etc/apt` | APT configuration | |
+| `/etc/apt/sources.list.d` | APT sources | |
+| `/usr/lib/systemd/system` | Vendor systemd units | |
+| `/usr/lib/systemd/user` | Vendor user units | |
+
+### 2. DHCP/Dhclient Files (5-10 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/lib/NetworkManager/*.lease` | NetworkManager leases | |
+| `/var/lib/NetworkManager/*.leases` | NM leases (alternate) | |
+| `/var/lib/dhclient/*.lease` | dhclient leases | |
+| `/var/lib/dhclient/*.leases` | dhclient leases (alternate) | |
+| `/var/lib/dhcp/*.lease` | ISC DHCP leases | |
+| `/var/lib/dhcp/*.leases` | ISC DHCP leases (alternate) | |
+
+### 3. Networking Files (15-25 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/netplan/*.yaml` | Netplan configuration | |
+| `/etc/dhcp/*.conf` | DHCP client config | |
+| `/etc/network/interfaces` | Legacy network config | |
+| `/etc/network/interfaces.d/*.cfg` | Interface includes | |
+| `/etc/ufw/ufw.conf` | UFW firewall config | |
+| `/etc/ufw/user.rules` | UFW IPv4 rules | |
+| `/etc/ufw/user6.rules` | UFW IPv6 rules | |
+| `/etc/ssh/sshd_config` | SSH daemon config | |
+| `/etc/ssh/sshd_config.d/*` | SSH config includes | |
+| `/etc/nsswitch.conf` | Name service switch | |
+| `/etc/resolv.conf` | DNS resolver config | |
+| `/etc/hosts` | Static host mappings | X |
+| `/etc/hosts.allow` | TCP wrappers allow | |
+| `/etc/hosts.deny` | TCP wrappers deny | |
+| `/etc/pam.d/*` | PAM configuration | X |
+
+### 4. NetworkManager Files (5-15 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/usr/lib/NetworkManager/*.conf` | Vendor NM config | |
+| `/usr/lib/NetworkManager/conf.d/*.conf` | Vendor NM includes | |
+| `/etc/NetworkManager/*.conf` | System NM config | |
+| `/etc/NetworkManager/conf.d/*.conf` | System NM includes | |
+| `/var/lib/NetworkManager/*.conf` | Runtime NM config | |
+| `/var/lib/NetworkManager/conf.d/*.conf` | Runtime NM includes | |
+| `/var/lib/NetworkManager/*.state` | NM state files | |
+
+### 5. Package Management Log Files (10-20 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/dpkg*` | dpkg package logs | |
+| `/var/log/apt/*` | APT logs | |
+| `/var/log/unattended-upgrades/*` | Auto-update logs | |
+
+### 6. System Log Files (15-30 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/var/log/syslog*` | System log | |
+| `/var/log/rsyslog*` | Rsyslog output | |
+| `/var/log/messages*` | System messages (fallback) | |
+| `/var/log/kern*` | Kernel messages | |
+| `/var/log/dmesg*` | Boot ring buffer | |
+| `/var/log/boot*` | Boot logs | |
+| `/var/log/auth*` | Authentication log | X |
+| `/var/log/secure*` | Secure log (fallback) | X |
+| `/var/log/pacemaker*` | Pacemaker cluster | |
+| `/var/log/corosync*` | Corosync cluster | |
+| `/var/log/cluster/*` | Cluster logs | |
+| `/var/log/pacemaker/*` | Pacemaker directory | |
+| `/var/log/corosync/*` | Corosync directory | |
+
+### 7. System Configuration Files (15-25 files)
+
+| Path | Purpose | X |
+|------|---------|---|
+| `/etc/fstab` | Filesystem mounts | |
+| `/etc/crypttab` | Encrypted volumes | X |
+| `/etc/*-release` | OS release info | |
+| `/etc/HOSTNAME` | Hostname (legacy) | |
+| `/etc/hostname` | Hostname | |
+| `/etc/localtime` | Timezone symlink | |
+| `/etc/chrony/chrony.conf` | Chrony NTP config | |
+| `/etc/idmapd.conf` | NFSv4 ID mapping | |
+| `/etc/sudoers` | Sudo configuration | X |
+| `/etc/sudoers.d/*` | Sudo includes | X |
+| `/etc/sysctl.conf` | Kernel parameters | |
+| `/etc/sysctl.d/*.conf` | Sysctl includes | |
+| `/etc/udev/rules.d/*.rules` | Device rules | |
+| `/etc/modprobe.d/*.conf` | Kernel module config | |
+| `/etc/security/limits.conf` | Resource limits | |
+| `/sys/kernel/security/apparmor/profiles` | AppArmor profiles | |
+
+### 8. Disk Info (1 item)
+
+| Command | Purpose | X |
+|---------|---------|---|
+| `diskinfo,` | Disk partition info | |
+
+---
+
+## Legend
+
+**X Column:** Items marked with X may contain sensitive or personally identifiable information (PII):
+- Authentication logs with usernames
+- Encrypted volume passphrases
+- Sudo user configurations
+- Host-specific network information
+
+---
+
+## Potentially Missing Items
+
+### Boot and Kernel
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| GRUB configuration | `/boot/grub/grub.cfg`, `/etc/default/grub` | Boot parameter issues |
+| Kernel crash dumps | `/var/crash/*` | Kernel panic analysis |
+| initramfs logs | `/var/log/mkinitramfs.log` | Boot issues |
+
+### APT/Package Management
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| APT sources | `/etc/apt/sources.list` | Repository configuration |
+| APT preferences | `/etc/apt/preferences.d/*` | Package pinning |
+| dpkg status | `/var/lib/dpkg/status` | Installed packages |
+
+### Systemd
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| Journal export | `journalctl` output | Comprehensive logs |
+| Failed units | `systemctl --failed` | Service failures |
+| Service overrides | `/etc/systemd/system/*.d/*.conf` | Custom settings |
+
+### Security
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| AppArmor logs | `/var/log/audit/audit.log` | Policy denials |
+| fail2ban logs | `/var/log/fail2ban.log` | SSH brute force |
+| UFW logs | `/var/log/ufw.log` | Firewall events |
+
+### Network
+| Item | Path | Why It's Useful |
+|------|------|-----------------|
+| netplan rendered config | `/run/netplan/*.yaml` | Applied config |
+| systemd-resolved | `/etc/systemd/resolved.conf` | DNS resolution |
+| Wireguard config | `/etc/wireguard/*.conf` | VPN configuration |

--- a/manifests/linux/diagnostic-authlog-common
+++ b/manifests/linux/diagnostic-authlog-common
@@ -1,0 +1,8 @@
+echo,### Gathering Authentication Log Files ###
+copy,/var/log/auth*
+copy,/var/log/secure*
+copy,/var/log/faillog
+copy,/var/log/lastlog
+copy,/var/log/btmp*
+copy,/var/log/wtmp*
+echo,

--- a/manifests/linux/diagnostic-azure-agent-config
+++ b/manifests/linux/diagnostic-azure-agent-config
@@ -1,0 +1,4 @@
+echo,### Gathering Azure Agent Configuration ###
+copy,/etc/waagent.conf
+copy,/etc/waagent.conf.bak
+echo,

--- a/manifests/linux/diagnostic-azure-agent-identity
+++ b/manifests/linux/diagnostic-azure-agent-identity
@@ -1,0 +1,4 @@
+echo,### Gathering Managed Identity Files ###
+copy,/var/lib/waagent/ManagedIdentity-*.json
+copy,/var/lib/waagent/*/ManagedIdentity-*.json
+echo,

--- a/manifests/linux/diagnostic-azure-agent-logs
+++ b/manifests/linux/diagnostic-azure-agent-logs
@@ -1,0 +1,3 @@
+echo,### Gathering Azure Linux Agent - waagent - Log Files ###
+copy,/var/log/waagent*
+echo,

--- a/manifests/linux/diagnostic-azure-agent-probing
+++ b/manifests/linux/diagnostic-azure-agent-probing
@@ -1,0 +1,5 @@
+echo,### Probing Azure Agent Directories ###
+ll,/var/log
+ll,/var/lib/waagent
+ll,/var/lib/waagent/history
+echo,

--- a/manifests/linux/diagnostic-azure-agent-proxyagent
+++ b/manifests/linux/diagnostic-azure-agent-proxyagent
@@ -1,0 +1,4 @@
+echo,### Gathering Guest ProxyAgent Log Files ###
+copy,/var/log/azure-proxy-agent/*
+copy,/var/log/azure-proxy-agent.*
+echo,

--- a/manifests/linux/diagnostic-azure-agent-state
+++ b/manifests/linux/diagnostic-azure-agent-state
@@ -1,0 +1,9 @@
+echo,### Gathering Azure Linux Agent State Files ###
+copy,/var/lib/waagent/provisioned,noscan
+copy,/var/lib/waagent/waagent_status.json
+copy,/var/lib/waagent/waagent_status.*.json
+copy,/var/lib/waagent/Incarnation
+copy,/var/lib/waagent/error.json
+copy,/var/lib/waagent/*.agentsManifest
+copy,/var/lib/waagent/history/*.zip,noscan
+echo,

--- a/manifests/linux/diagnostic-azure-agent-xml
+++ b/manifests/linux/diagnostic-azure-agent-xml
@@ -1,0 +1,7 @@
+echo,### Gathering Azure Linux Agent XML Configuration ###
+copy,/var/lib/waagent/*.xml
+copy,/var/lib/waagent/SharedConfig.xml
+copy,/var/lib/waagent/HostingEnvironmentConfig.xml
+copy,/var/lib/waagent/GoalState.*.xml
+copy,/var/lib/waagent/ExtensionsConfig.*.xml
+echo,

--- a/manifests/linux/diagnostic-blobfuse-common
+++ b/manifests/linux/diagnostic-blobfuse-common
@@ -1,0 +1,5 @@
+echo,### Gathering Blobfuse Files ###
+copy,/var/log/blobfuse*
+copy,/var/log/blobfuse2.log*
+echo,
+

--- a/manifests/linux/diagnostic-bootconfig-common
+++ b/manifests/linux/diagnostic-bootconfig-common
@@ -1,0 +1,17 @@
+echo,### Probing Boot Directories ###
+ll,/boot
+ll,/boot/grub
+ll,/boot/grub2
+ll,/boot/loader/entries
+echo,
+
+echo,### Gathering Boot Configuration Files ###
+copy,/boot/grub/grub.cfg,noscan
+copy,/boot/grub/menu.lst,noscan
+copy,/boot/grub/grubenv,noscan
+copy,/boot/grub2/grub.cfg,noscan
+copy,/boot/grub2/grubenv,noscan
+copy,/etc/default/grub,noscan
+copy,/etc/default/grub.d/*.cfg,noscan
+copy,/boot/loader/entries/*.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-bootlog-common
+++ b/manifests/linux/diagnostic-bootlog-common
@@ -1,0 +1,3 @@
+echo,### Gathering Boot Log Files ###
+copy,/var/log/boot*
+echo,

--- a/manifests/linux/diagnostic-cloudinit-common
+++ b/manifests/linux/diagnostic-cloudinit-common
@@ -1,0 +1,12 @@
+echo,### Gathering Cloud-init Files ###
+ll,/run/cloud-init
+ll,/var/lib/cloud
+copy,/var/log/cloud-init*
+copy,/etc/cloud/cloud.cfg
+copy,/etc/cloud/cloud.cfg.d/*.cfg
+copy,/run/cloud-init/cloud.cfg
+copy,/run/cloud-init/ds-identify.log
+copy,/run/cloud-init/result.json
+copy,/run/cloud-init/status.json
+echo,
+

--- a/manifests/linux/diagnostic-cloudregister-suse
+++ b/manifests/linux/diagnostic-cloudregister-suse
@@ -1,0 +1,3 @@
+echo,### Gathering SUSE Cloud Registration Log ###
+copy,/var/log/cloudregister
+echo,

--- a/manifests/linux/diagnostic-clusterlog-common
+++ b/manifests/linux/diagnostic-clusterlog-common
@@ -1,0 +1,7 @@
+echo,### Gathering Cluster Log Files (Pacemaker/Corosync) ###
+copy,/var/log/pacemaker*
+copy,/var/log/corosync*
+copy,/var/log/cluster/*
+copy,/var/log/pacemaker/*
+copy,/var/log/corosync/*
+echo,

--- a/manifests/linux/diagnostic-dhcp-mariner
+++ b/manifests/linux/diagnostic-dhcp-mariner
@@ -1,0 +1,5 @@
+echo,### Gathering DHCP Files - Mariner ###
+copy,/var/lib/NetworkManager/*.lease,noscan
+copy,/var/lib/NetworkManager/*.leases,noscan
+copy,/run/systemd/netif/leases/*,noscan
+echo,

--- a/manifests/linux/diagnostic-dhcp-redhat
+++ b/manifests/linux/diagnostic-dhcp-redhat
@@ -1,0 +1,6 @@
+echo,### Gathering DHCP Files (RHEL/CentOS/Fedora) ###
+copy,/var/lib/NetworkManager/*.lease,noscan
+copy,/var/lib/NetworkManager/*.leases,noscan
+copy,/var/lib/dhclient/*.lease,noscan
+copy,/var/lib/dhclient/*.leases,noscan
+echo,

--- a/manifests/linux/diagnostic-dhcp-suse
+++ b/manifests/linux/diagnostic-dhcp-suse
@@ -1,0 +1,5 @@
+echo,### Gathering DHCP Files (SUSE - Wicked) ###
+copy,/var/lib/wicked/lease*,noscan
+copy,/var/lib/NetworkManager/*.lease,noscan
+copy,/var/lib/NetworkManager/*.leases,noscan
+echo,

--- a/manifests/linux/diagnostic-dhcp-ubuntu
+++ b/manifests/linux/diagnostic-dhcp-ubuntu
@@ -1,0 +1,8 @@
+echo,### Gathering DHCP Files (Ubuntu/Debian) ###
+copy,/var/lib/NetworkManager/*.lease,noscan
+copy,/var/lib/NetworkManager/*.leases,noscan
+copy,/var/lib/dhclient/*.lease,noscan
+copy,/var/lib/dhclient/*.leases,noscan
+copy,/var/lib/dhcp/*.lease,noscan
+copy,/var/lib/dhcp/*.leases,noscan
+echo,

--- a/manifests/linux/diagnostic-diskinfo-common
+++ b/manifests/linux/diagnostic-diskinfo-common
@@ -1,0 +1,3 @@
+echo,### Gathering Disk Info ###
+diskinfo,
+echo,

--- a/manifests/linux/diagnostic-dns-common
+++ b/manifests/linux/diagnostic-dns-common
@@ -1,0 +1,9 @@
+echo,### Gathering DNS/Name Resolution Files ###
+copy,/etc/resolv.conf,noscan
+copy,/etc/nsswitch.conf,noscan
+copy,/etc/hosts,noscan
+copy,/etc/hosts.allow,noscan
+copy,/etc/hosts.deny,noscan
+copy,/run/systemd/resolve/resolv.conf,noscan
+copy,/run/systemd/resolve/stub-resolv.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-extensions-handler
+++ b/manifests/linux/diagnostic-extensions-handler
@@ -1,0 +1,10 @@
+echo,### Extension Handler Configuration ###
+copy,/var/lib/waagent/*/error.json
+copy,/var/lib/waagent/*.manifest.xml
+copy,/var/lib/waagent/*/config/*.settings
+copy,/var/lib/waagent/*/config/HandlerState
+copy,/var/lib/waagent/*/config/HandlerStatus
+copy,/var/lib/waagent/*/status/*.status
+copy,/var/lib/waagent/*/config/VMApp.lockfile,noscan
+copy,/var/lib/waagent/*/config/applicationRegistry.active
+

--- a/manifests/linux/diagnostic-extensions-lad
+++ b/manifests/linux/diagnostic-extensions-lad
@@ -1,0 +1,10 @@
+echo,### Linux Diagnostic Extension LAD ###
+copy,/var/log/azure/Microsoft.*LinuxDiagnostic/*/*
+copy,/var/lib/waagent/Microsoft.*LinuxDiagnostic*/status/*.status
+copy,/var/lib/waagent/Microsoft.*LinuxDiagnostic*/config/*.settings
+copy,/var/lib/waagent/Microsoft.*LinuxDiagnostic*/xmlCfg.xml
+
+echo,### OMS Agent - used by LAD ###
+copy,/etc/opt/microsoft/omsagent/LAD/conf/omsagent.d/*
+copy,/var/opt/microsoft/omsagent/LAD/log/*
+

--- a/manifests/linux/diagnostic-extensions-logs
+++ b/manifests/linux/diagnostic-extensions-logs
@@ -1,0 +1,5 @@
+echo,### Extension Log Files ###
+copy,/var/log/azure/*
+copy,/var/log/azure/*/*
+copy,/var/log/azure/*/*/*
+

--- a/manifests/linux/diagnostic-extensions-monitoring
+++ b/manifests/linux/diagnostic-extensions-monitoring
@@ -1,0 +1,38 @@
+echo,### Azure Monitor Agent ###
+
+echo,### Azure Monitor Agent Event Cache ###
+ll,/var/opt/microsoft/azuremonitoragent/events
+
+echo,### Azure Monitor Agent Configuration ###
+copy,/etc/default/azuremonitoragent
+copy,/etc/opt/microsoft/azuremonitoragent/dmiinfo.txt
+copy,/etc/opt/microsoft/azuremonitoragent/amacoreagent/*
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/configchunks/*
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/configtransformid.txt
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/fluentbit/*.conf
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/mcsconfig*
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/mdsd*
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/metricCounters.json
+copy,/etc/opt/microsoft/azuremonitoragent/config-cache/syslog*
+
+echo,### Azure Monitor Agent Logs ###
+copy,/var/opt/microsoft/azuremonitoragent/log/*
+
+echo,### Azure Monitor Agent State ###
+copy,/var/opt/microsoft/azuremonitoragent/events/taskstate.json
+
+echo,### Telegraf Configuration ###
+copy,/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*/config/telegraf_configs/telegraf.conf
+copy,/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*/config/telegraf_configs/telegraf.d/*
+
+echo,### MetricsExtension Configuration ###
+copy,/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*/config/metrics_configs/*Configuration.json
+
+echo,### Azure Monitor Agent Extension Handler ###
+copy,/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*/*
+copy,/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*/config/*.settings
+copy,/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*/status/*.status
+
+echo,### Azure Monitor Agent Extension Logs ###
+copy,/var/log/azure/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent/*/*.log
+

--- a/manifests/linux/diagnostic-extensions-probing
+++ b/manifests/linux/diagnostic-extensions-probing
@@ -1,0 +1,5 @@
+echo,### Extension Directory Listings ###
+ll,/var/lib/waagent
+ll,/var/log/azure
+ll,/opt/azure/containers
+

--- a/manifests/linux/diagnostic-extensions-servicefabric
+++ b/manifests/linux/diagnostic-extensions-servicefabric
@@ -1,0 +1,19 @@
+echo,### Service Fabric Extension ###
+copy,/var/log/azure/Microsoft.Azure.KeyVault.KeyVaultForLinux/*
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/extension.log
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/handler.log
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/ServiceFabricLinuxExtension.log
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/CommandExecution*.log
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/sfbootstrapagent*.log
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/InfrastructureManifest.xml
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode/TempClusterManifest.xml
+copy,/var/log/azure/Microsoft.Azure.ServiceFabric.ServiceFabricLinuxNode/events/*
+
+echo,### Key Vault Extension Config ###
+copy,/var/lib/waagent/Microsoft.Azure.KeyVault.KeyVaultForLinux-*/config/*
+
+echo,### Service Fabric Extension Handler ###
+copy,/var/lib/waagent/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode-*/heartbeat.log,noscan
+copy,/var/lib/waagent/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode-*.*/HandlerEnvironment.json
+copy,/var/lib/waagent/Microsoft.Azure.ServiceFabric.*ServiceFabricLinuxNode-*/HandlerManifest.json
+

--- a/manifests/linux/diagnostic-extensions-siterecovery
+++ b/manifests/linux/diagnostic-extensions-siterecovery
@@ -1,0 +1,7 @@
+echo,### Site Recovery Extension ###
+copy,/var/log/ua_install.log
+copy,/var/log/AzureRcmCli.log
+copy,/var/log/svagents*.log
+copy,/var/log/s2*.log
+copy,/var/log/evtcollforw*.log
+

--- a/manifests/linux/diagnostic-extensions-sqliaas
+++ b/manifests/linux/diagnostic-extensions-sqliaas
@@ -1,0 +1,18 @@
+echo,### SQL IaaS Extension ###
+ll,/var/opt/mssql
+copy,/var/log/azure/Microsoft.SqlServer.Management.SqlIaaSAgentLinux*,noscan
+copy,/var/lib/waagent/Microsoft.SqlServer.Management.SqlIaaSAgentLinux*/deployer.log,noscan
+copy,/var/lib/waagent/Microsoft.SqlServer.Management.SqlIaaSAgentLinux*/status/*
+copy,/var/lib/waagent/Microsoft.SqlServer.Management.SqlIaaSAgentLinux*/config/*,noscan
+copy,/var/lib/waagent/Microsoft.SqlServer.Management.SqlIaaSAgentLinux*/HandlerManifest.json,noscan
+copy,/var/lib/waagent/Microsoft.SqlServer.Management.SqlIaaSAgentLinux*/HandlerEnvironment.json,noscan
+
+echo,### SQL Server Installation ###
+copy,/var/opt/mssql/setup*
+
+echo,### SQL Server Logs ###
+copy,/opt/mssql/bin/mssql-conf
+copy,/var/opt/mssql/log/errorlog*
+copy,/var/opt/mssql/log/*.tar.gz2
+copy,/var/opt/mssql/log/*.mdmp
+

--- a/manifests/linux/diagnostic-extensions-workloadbackup
+++ b/manifests/linux/diagnostic-extensions-workloadbackup
@@ -1,0 +1,15 @@
+echo,### Workload Backup Extension ###
+copy,/var/spool/cron/tabs/root
+copy,/opt/msawb/etc/config/SAPHana/*
+copy,/opt/msawb/etc/config/global.json
+copy,/opt/msawb/var/lib/catalog/AutoHealCatalog/AutoHealTask/*.bin
+copy,/opt/msawb/var/lib/catalog/InquiryCatalog/*/*.bin
+copy,/opt/msawb/var/lib/catalog/WorkloadExtDatasourceCatalog/*/*.bin
+copy,/opt/msawb/var/lib/catalog/WorkloadSchedules/*/*.bin
+copy,/opt/msawb/var/lib/catalog/SyncObjectsCatalog/DatasourceSyncTable/*.bin
+copy,/opt/msawb/var/lib/catalog/SyncObjectsCatalog/AlertEventsTable/*.bin
+copy,/opt/msawb/bin/AzureWLBackupCommonManagementSettings.json
+copy,/opt/msawb/bin/AzureWLBackupMonitoringSync_config.json
+copy,/opt/msawb/var/log/*/*/*
+copy,/opt/msawb/var/log/*/*/*/*/*
+

--- a/manifests/linux/diagnostic-firewall-mariner
+++ b/manifests/linux/diagnostic-firewall-mariner
@@ -1,0 +1,6 @@
+echo,### Gathering Firewall Configuration (Mariner) ###
+copy,/etc/sysconfig/iptables,noscan
+copy,/etc/nftables.conf,noscan
+copy,/etc/firewalld/*.xml,noscan
+copy,/etc/firewalld/zones/*.xml,noscan
+echo,

--- a/manifests/linux/diagnostic-firewall-redhat
+++ b/manifests/linux/diagnostic-firewall-redhat
@@ -1,0 +1,7 @@
+echo,### Gathering Firewall Configuration - RHEL CentOS Fedora ###
+copy,/etc/sysconfig/iptables,noscan
+copy,/etc/sysconfig/ip6tables,noscan
+copy,/etc/firewalld/*.xml,noscan
+copy,/etc/firewalld/zones/*.xml,noscan
+copy,/etc/firewalld/services/*.xml,noscan
+echo,

--- a/manifests/linux/diagnostic-firewall-suse
+++ b/manifests/linux/diagnostic-firewall-suse
@@ -1,0 +1,6 @@
+echo,### Gathering Firewall Configuration (SUSE) ###
+copy,/etc/sysconfig/SuSEfirewall2,noscan
+copy,/etc/sysconfig/SuSEfirewall2.d/*,noscan
+copy,/etc/firewalld/*.xml,noscan
+copy,/etc/firewalld/zones/*.xml,noscan
+echo,

--- a/manifests/linux/diagnostic-firewall-ubuntu
+++ b/manifests/linux/diagnostic-firewall-ubuntu
@@ -1,0 +1,8 @@
+echo,### Gathering Firewall Configuration (Ubuntu/Debian - UFW) ###
+copy,/etc/ufw/ufw.conf,noscan
+copy,/etc/ufw/user.rules
+copy,/etc/ufw/user6.rules
+copy,/etc/ufw/before.rules
+copy,/etc/ufw/after.rules
+copy,/etc/default/ufw,noscan
+echo,

--- a/manifests/linux/diagnostic-fstab-common
+++ b/manifests/linux/diagnostic-fstab-common
@@ -1,0 +1,6 @@
+echo,### Gathering Filesystem Mount Configuration ###
+copy,/etc/fstab
+copy,/etc/crypttab
+copy,/etc/mdadm.conf
+copy,/etc/mdadm/mdadm.conf
+echo,

--- a/manifests/linux/diagnostic-hpc-common
+++ b/manifests/linux/diagnostic-hpc-common
@@ -1,0 +1,68 @@
+echo,### Probing HPC Directories ###
+ll,/sys/class/infiniband/
+ll,/sched/sge/
+ll,/var/log/slurmctld/
+ll,/var/log/slurmd/
+ll,/var/spool/pbs/
+echo,
+
+echo,### Gathering NVIDIA/CUDA Installer Logs ###
+copy,/var/log/cuda-installer.log
+copy,/var/log/nvidia-installer.log
+echo,
+
+echo,### Gathering Slurm Files ###
+copy,/etc/slurm/*
+copy,/var/log/slurmctld/slurmctld.log
+copy,/var/log/slurmd/slurmd.log
+echo,
+
+echo,### Gathering PBS Files ###
+copy,/etc/pbs.conf
+copy,/var/spool/pbs/mom_logs/*
+copy,/var/spool/pbs/sched_logs/*
+echo,
+
+echo,### Gathering SGE Files ###
+copy,/sched/sge/sge-2011.11/default/common/install_logs/*
+copy,/sched/sge/sge-2011.11/default/spool/*
+echo,
+
+echo,### Gathering System Limits ###
+copy,/etc/security/limits.conf,noscan
+echo,
+
+echo,### Gathering InfiniBand State ###
+copy,/sys/class/infiniband/mlx5_ib0/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib1/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib2/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib3/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib4/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib5/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib6/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib7/ports/1/state,noscan
+copy,/sys/class/infiniband/mlx5_ib0/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib1/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib2/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib3/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib4/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib5/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib6/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib7/ports/1/rate,noscan
+copy,/sys/class/infiniband/mlx5_ib0/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib1/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib2/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib3/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib4/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib5/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib6/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib7/ports/1/phys_state,noscan
+copy,/sys/class/infiniband/mlx5_ib0/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib1/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib2/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib3/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib4/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib5/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib6/ports/1/pkeys,noscan
+copy,/sys/class/infiniband/mlx5_ib7/ports/1/pkeys,noscan
+echo,

--- a/manifests/linux/diagnostic-kernlog-common
+++ b/manifests/linux/diagnostic-kernlog-common
@@ -1,0 +1,4 @@
+echo,### Gathering Kernel Log Files ###
+copy,/var/log/kern*
+copy,/var/log/dmesg*
+echo,

--- a/manifests/linux/diagnostic-kubernetes-aks
+++ b/manifests/linux/diagnostic-kubernetes-aks
@@ -1,0 +1,12 @@
+echo,### Gathering AKS Kubernetes Component Files ###
+copy,/var/log/kubelet.log
+copy,/var/log/containerd.log
+copy,/var/log/docker.log
+copy,/var/log/journal/*/*,noscan
+copy,/etc/kubernetes/*.conf,noscan
+copy,/etc/kubernetes/*.yaml,noscan
+copy,/etc/kubernetes/manifests/*.yaml,noscan
+copy,/var/lib/kubelet/config.yaml,noscan
+copy,/etc/containerd/config.toml,noscan
+copy,/etc/docker/daemon.json,noscan
+echo,

--- a/manifests/linux/diagnostic-kubernetes-common
+++ b/manifests/linux/diagnostic-kubernetes-common
@@ -1,0 +1,10 @@
+echo,### Gathering Kubernetes/Container Files ###
+copy,/var/log/pods/*/*/*.log
+copy,/var/log/containers/*.log
+copy,/etc/kubernetes/*.conf
+copy,/etc/kubernetes/*.yaml
+copy,/var/lib/kubelet/config.yaml
+copy,/var/log/kubelet.log
+copy,/etc/containerd/config.toml
+copy,/var/log/containerd.log
+echo,

--- a/manifests/linux/diagnostic-netconfig-mariner
+++ b/manifests/linux/diagnostic-netconfig-mariner
@@ -1,0 +1,8 @@
+echo,### Gathering Network Configuration (Mariner) ###
+copy,/etc/systemd/network/*.network,noscan
+copy,/etc/systemd/network/*.netdev,noscan
+copy,/etc/systemd/network/*.link,noscan
+copy,/run/systemd/network/*.network,noscan
+copy,/usr/lib/systemd/network/*.network,noscan
+copy,/etc/dhcp/*.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-netconfig-redhat
+++ b/manifests/linux/diagnostic-netconfig-redhat
@@ -1,0 +1,6 @@
+echo,### Gathering Network Configuration (RHEL/CentOS/Fedora) ###
+copy,/etc/sysconfig/network,noscan
+copy,/etc/sysconfig/network-scripts/ifcfg-*,noscan
+copy,/etc/sysconfig/network-scripts/route-*,noscan
+copy,/etc/dhcp/*.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-netconfig-suse
+++ b/manifests/linux/diagnostic-netconfig-suse
@@ -1,0 +1,9 @@
+echo,### Gathering Network Configuration (SUSE) ###
+copy,/etc/sysconfig/network,noscan
+copy,/etc/sysconfig/network/ifcfg-*,noscan
+copy,/etc/sysconfig/network/routes,noscan
+copy,/etc/sysconfig/network/ifroute-*,noscan
+copy,/etc/wicked/*.xml,noscan
+copy,/etc/wicked/ifconfig/*.xml,noscan
+copy,/etc/dhcp/*.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-netconfig-ubuntu
+++ b/manifests/linux/diagnostic-netconfig-ubuntu
@@ -1,0 +1,6 @@
+echo,### Gathering Network Configuration (Ubuntu/Debian) ###
+copy,/etc/netplan/*.yaml,noscan
+copy,/etc/network/interfaces,noscan
+copy,/etc/network/interfaces.d/*.cfg,noscan
+copy,/etc/dhcp/*.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-networking-aks
+++ b/manifests/linux/diagnostic-networking-aks
@@ -1,0 +1,11 @@
+echo,### Gathering AKS Networking Logs ###
+copy,/var/log/azure-cni*
+copy,/var/log/azure-vnet*
+copy,/var/log/azure-ipam*
+copy,/var/log/azure-cns*,noscan
+copy,/var/log/azure-npm.log,noscan
+copy,/var/log/cilium-cni*
+copy,/var/run/azure-vnet*
+copy,/run/azure-vnet*
+copy,/etc/cni/net.d/*.conflist,noscan
+echo,

--- a/manifests/linux/diagnostic-networkmanager-common
+++ b/manifests/linux/diagnostic-networkmanager-common
@@ -1,0 +1,9 @@
+echo,### Gathering NetworkManager Files ###
+copy,/usr/lib/NetworkManager/*.conf,noscan
+copy,/usr/lib/NetworkManager/conf.d/*.conf,noscan
+copy,/etc/NetworkManager/*.conf,noscan
+copy,/etc/NetworkManager/conf.d/*.conf,noscan
+copy,/var/lib/NetworkManager/*.conf,noscan
+copy,/var/lib/NetworkManager/conf.d/*.conf,noscan
+copy,/var/lib/NetworkManager/*.state,noscan
+echo,

--- a/manifests/linux/diagnostic-nfs-common
+++ b/manifests/linux/diagnostic-nfs-common
@@ -1,0 +1,6 @@
+echo,### Gathering NFS/IDMap Configuration ###
+copy,/etc/idmapd.conf,noscan
+copy,/etc/nfs.conf,noscan
+copy,/etc/nfsmount.conf,noscan
+copy,/etc/exports
+echo,

--- a/manifests/linux/diagnostic-packages-mariner
+++ b/manifests/linux/diagnostic-packages-mariner
@@ -1,0 +1,6 @@
+echo,### Gathering Package Management Log Files (Mariner - TDNF) ###
+copy,/var/log/tdnf*,noscan
+copy,/var/log/dnf*,noscan
+copy,/var/log/yum*,noscan
+copy,/var/cache/tdnf/history/*,noscan
+echo,

--- a/manifests/linux/diagnostic-packages-redhat
+++ b/manifests/linux/diagnostic-packages-redhat
@@ -1,0 +1,10 @@
+echo,### Gathering Package Management Log Files (RHEL/CentOS/Fedora) ###
+copy,/var/log/yum*,noscan
+copy,/var/log/dnf*,noscan
+copy,/var/log/rhsm/*,noscan
+echo,
+
+echo,### Gathering Red Hat Update Infrastructure Log Files ###
+copy,/var/log/rhuicheck.log
+copy,/var/log/rhui/*
+echo,

--- a/manifests/linux/diagnostic-packages-suse
+++ b/manifests/linux/diagnostic-packages-suse
@@ -1,0 +1,4 @@
+echo,### Gathering Package Management Log Files (SUSE) ###
+copy,/var/log/zypp/history,noscan
+copy,/var/log/zypper.log,noscan
+echo,

--- a/manifests/linux/diagnostic-packages-ubuntu
+++ b/manifests/linux/diagnostic-packages-ubuntu
@@ -1,0 +1,5 @@
+echo,### Gathering Package Management Log Files (Ubuntu/Debian) ###
+copy,/var/log/dpkg*,noscan
+copy,/var/log/apt/*,noscan
+copy,/var/log/unattended-upgrades/*,noscan
+echo,

--- a/manifests/linux/diagnostic-pam-common
+++ b/manifests/linux/diagnostic-pam-common
@@ -1,0 +1,6 @@
+echo,### Gathering PAM Configuration ###
+copy,/etc/pam.d/*
+copy,/etc/security/access.conf,noscan
+copy,/etc/security/limits.conf,noscan
+copy,/etc/security/limits.d/*,noscan
+echo,

--- a/manifests/linux/diagnostic-pods-aks
+++ b/manifests/linux/diagnostic-pods-aks
@@ -1,0 +1,10 @@
+echo,### Gathering AKS Pod Logs ###
+copy,/var/log/pods/kube-system*/*/*.log*
+copy,/var/log/pods/calico-system*/*/*.log*
+copy,/var/log/pods/tigera-operator*/*/*.log*
+copy,/var/log/pods/kured*/*/*.log*
+copy,/var/log/pods/dataprotection-microsoft*/*/*.log*
+copy,/var/log/pods/azure*/*/*.log*
+copy,/var/log/containers/*.log
+ll,/var/log/pods/*/*
+echo,

--- a/manifests/linux/diagnostic-probing-aks
+++ b/manifests/linux/diagnostic-probing-aks
@@ -1,0 +1,9 @@
+echo,### Probing AKS Directories ###
+ll,/var/log
+ll,/var/log/azure/
+ll,/var/log/pods
+ll,/var/log/containers
+ll,/opt/azure/containers/
+ll,/etc/kubernetes
+ll,/etc/cni/net.d
+echo,

--- a/manifests/linux/diagnostic-probing-mariner
+++ b/manifests/linux/diagnostic-probing-mariner
@@ -1,0 +1,17 @@
+echo,### Probing Directories (Mariner) ###
+ll,/boot
+ll,/var/log
+ll,/var/lib/cloud
+ll,/var/lib/waagent
+ll,/etc
+ll,/etc/udev/rules.d
+ll,/etc/alternatives
+ll,/etc/systemd/system
+ll,/etc/systemd/system/multi-user.target.wants
+ll,/etc/systemd/system/graphical.target.wants
+ll,/etc/systemd/user
+ll,/etc/yum.repos.d
+ll,/etc/tdnf
+ll,/usr/lib/systemd/system
+ll,/usr/lib/systemd/user
+echo,

--- a/manifests/linux/diagnostic-probing-redhat
+++ b/manifests/linux/diagnostic-probing-redhat
@@ -1,0 +1,16 @@
+echo,### Probing Directories (RHEL/CentOS/Fedora) ###
+ll,/boot
+ll,/var/log
+ll,/var/lib/cloud
+ll,/var/lib/waagent
+ll,/etc
+ll,/etc/udev/rules.d
+ll,/etc/alternatives
+ll,/etc/systemd/system
+ll,/etc/systemd/system/multi-user.target.wants
+ll,/etc/systemd/system/graphical.target.wants
+ll,/etc/systemd/user
+ll,/etc/yum.repos.d
+ll,/usr/lib/systemd/system
+ll,/usr/lib/systemd/user
+echo,

--- a/manifests/linux/diagnostic-probing-suse
+++ b/manifests/linux/diagnostic-probing-suse
@@ -1,0 +1,16 @@
+echo,### Probing Directories (SUSE) ###
+ll,/boot
+ll,/var/log
+ll,/var/lib/cloud
+ll,/var/lib/waagent
+ll,/etc
+ll,/etc/udev/rules.d
+ll,/etc/alternatives
+ll,/etc/systemd/system
+ll,/etc/systemd/system/multi-user.target.wants
+ll,/etc/systemd/system/graphical.target.wants
+ll,/etc/systemd/user
+ll,/etc/zypp/repos.d
+ll,/usr/lib/systemd/system
+ll,/usr/lib/systemd/user
+echo,

--- a/manifests/linux/diagnostic-probing-ubuntu
+++ b/manifests/linux/diagnostic-probing-ubuntu
@@ -1,0 +1,17 @@
+echo,### Probing Directories (Ubuntu/Debian) ###
+ll,/boot
+ll,/var/log
+ll,/var/lib/cloud
+ll,/var/lib/waagent
+ll,/etc
+ll,/etc/udev/rules.d
+ll,/etc/alternatives
+ll,/etc/systemd/system
+ll,/etc/systemd/system/multi-user.target.wants
+ll,/etc/systemd/system/graphical.target.wants
+ll,/etc/systemd/user
+ll,/etc/apt
+ll,/etc/apt/sources.list.d
+ll,/usr/lib/systemd/system
+ll,/usr/lib/systemd/user
+echo,

--- a/manifests/linux/diagnostic-provision-aks
+++ b/manifests/linux/diagnostic-provision-aks
@@ -1,0 +1,6 @@
+echo,### Gathering AKS Cluster Provisioning Scripts ###
+ll,/opt/azure/containers
+copy,/opt/azure/containers/*.sh
+copy,/opt/azure/containers/*.log
+copy,/opt/azure/containers/*.txt
+echo,

--- a/manifests/linux/diagnostic-release-common
+++ b/manifests/linux/diagnostic-release-common
@@ -1,0 +1,7 @@
+echo,### Gathering OS Release and Hostname ###
+copy,/etc/*-release,noscan
+copy,/etc/os-release,noscan
+copy,/etc/HOSTNAME,noscan
+copy,/etc/hostname,noscan
+copy,/etc/machine-id,noscan
+echo,

--- a/manifests/linux/diagnostic-repoconfig-mariner
+++ b/manifests/linux/diagnostic-repoconfig-mariner
@@ -1,0 +1,10 @@
+echo,### Probing Repository Directories - Mariner ###
+ll,/etc/yum.repos.d
+ll,/etc/tdnf
+echo,
+
+echo,### Gathering Repository Configuration Files - Mariner ###
+copy,/etc/tdnf/tdnf.conf,noscan
+copy,/etc/yum.repos.d/*.repo,noscan
+copy,/etc/dnf/dnf.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-repoconfig-redhat
+++ b/manifests/linux/diagnostic-repoconfig-redhat
@@ -1,0 +1,12 @@
+echo,### Probing Repository Directories - RHEL CentOS Fedora ###
+ll,/etc/yum.repos.d
+echo,
+
+echo,### Gathering Repository Configuration Files - RHEL CentOS Fedora ###
+copy,/etc/yum.conf,noscan
+copy,/etc/yum.repos.d/*.repo,noscan
+copy,/etc/yum/vars/releasever,noscan
+copy,/etc/dnf/dnf.conf,noscan
+copy,/etc/dnf/vars/releasever,noscan
+copy,/etc/yum.repos.d/rh-cloud-rhel*.repo,noscan
+echo,

--- a/manifests/linux/diagnostic-repoconfig-suse
+++ b/manifests/linux/diagnostic-repoconfig-suse
@@ -1,0 +1,11 @@
+echo,### Probing Repository Directories - SUSE ###
+ll,/etc/products.d
+ll,/etc/zypp/repos.d
+echo,
+
+echo,### Gathering Repository Configuration Files - SUSE ###
+copy,/etc/products.d/*.prod,noscan
+copy,/etc/zypp/repos.d/*.repo,noscan
+copy,/etc/zypp/zypp.conf,noscan
+copy,/etc/regionserverclnt.cfg,noscan
+echo,

--- a/manifests/linux/diagnostic-repoconfig-ubuntu
+++ b/manifests/linux/diagnostic-repoconfig-ubuntu
@@ -1,0 +1,12 @@
+echo,### Probing Repository Directories - Ubuntu Debian ###
+ll,/etc/apt
+ll,/etc/apt/sources.list.d
+echo,
+
+echo,### Gathering Repository Configuration Files - Ubuntu Debian ###
+copy,/etc/apt/sources.list,noscan
+copy,/etc/apt/sources.list.d/*.list,noscan
+copy,/etc/apt/sources.list.d/*.sources,noscan
+copy,/etc/apt/preferences,noscan
+copy,/etc/apt/preferences.d/*,noscan
+echo,

--- a/manifests/linux/diagnostic-security-mariner
+++ b/manifests/linux/diagnostic-security-mariner
@@ -1,0 +1,4 @@
+echo,### Gathering SELinux Security Configuration ###
+copy,/etc/selinux/config,noscan
+ll,/etc/selinux
+echo,

--- a/manifests/linux/diagnostic-security-redhat
+++ b/manifests/linux/diagnostic-security-redhat
@@ -1,0 +1,5 @@
+echo,### Gathering SELinux Security Configuration ###
+copy,/etc/selinux/config,noscan
+copy,/etc/sysconfig/selinux,noscan
+ll,/etc/selinux
+echo,

--- a/manifests/linux/diagnostic-security-suse
+++ b/manifests/linux/diagnostic-security-suse
@@ -1,0 +1,6 @@
+echo,### Gathering AppArmor Security Configuration ###
+copy,/sys/kernel/security/apparmor/profiles,noscan
+copy,/etc/apparmor/parser.conf,noscan
+copy,/etc/apparmor.d/*.conf,noscan
+ll,/etc/apparmor.d
+echo,

--- a/manifests/linux/diagnostic-security-ubuntu
+++ b/manifests/linux/diagnostic-security-ubuntu
@@ -1,0 +1,6 @@
+echo,### Gathering AppArmor Security Configuration ###
+copy,/sys/kernel/security/apparmor/profiles,noscan
+copy,/etc/apparmor/parser.conf,noscan
+copy,/etc/apparmor.d/*.conf,noscan
+ll,/etc/apparmor.d
+echo,

--- a/manifests/linux/diagnostic-sosreport-common
+++ b/manifests/linux/diagnostic-sosreport-common
@@ -1,0 +1,11 @@
+echo,### Probing SOS/Supportconfig Directories ###
+ll,/var/tmp
+ll,/tmp
+echo,
+
+echo,### Gathering sosreport Files - RHEL Ubuntu ###
+copy,/var/tmp/sosreport*.tar.xz,noscan
+copy,/var/tmp/sosreport*.tar.gz,noscan
+copy,/tmp/sosreport*.tar.xz,noscan
+copy,/tmp/sosreport*.tar.gz,noscan
+echo,

--- a/manifests/linux/diagnostic-ssh-common
+++ b/manifests/linux/diagnostic-ssh-common
@@ -1,0 +1,6 @@
+echo,### Gathering SSH Configuration ###
+copy,/etc/ssh/sshd_config
+copy,/etc/ssh/sshd_config.d/*
+copy,/etc/ssh/ssh_config
+copy,/etc/ssh/ssh_config.d/*
+echo,

--- a/manifests/linux/diagnostic-sudoers-common
+++ b/manifests/linux/diagnostic-sudoers-common
@@ -1,0 +1,4 @@
+echo,### Gathering Sudoers Configuration ###
+copy,/etc/sudoers,noscan
+copy,/etc/sudoers.d/*,noscan
+echo,

--- a/manifests/linux/diagnostic-supportconfig-suse
+++ b/manifests/linux/diagnostic-supportconfig-suse
@@ -1,0 +1,8 @@
+echo,### Probing Supportconfig Directories ###
+ll,/var/log
+echo,
+
+echo,### Gathering supportconfig Files - SUSE ###
+copy,/var/log/scc*.txz,noscan
+copy,/var/log/scc*.tar.xz,noscan
+echo,

--- a/manifests/linux/diagnostic-sysctl-common
+++ b/manifests/linux/diagnostic-sysctl-common
@@ -1,0 +1,5 @@
+echo,### Gathering Sysctl Configuration ###
+copy,/etc/sysctl.conf,noscan
+copy,/etc/sysctl.d/*.conf,noscan
+copy,/usr/lib/sysctl.d/*.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-syslog-common
+++ b/manifests/linux/diagnostic-syslog-common
@@ -1,0 +1,5 @@
+echo,### Gathering System Log Files - syslog and messages ###
+copy,/var/log/syslog*
+copy,/var/log/rsyslog*
+copy,/var/log/messages*
+echo,

--- a/manifests/linux/diagnostic-time-common
+++ b/manifests/linux/diagnostic-time-common
@@ -1,0 +1,8 @@
+echo,### Gathering Time Configuration ###
+copy,/etc/localtime,noscan
+copy,/etc/timezone,noscan
+copy,/etc/chrony.conf,noscan
+copy,/etc/chrony/chrony.conf,noscan
+copy,/etc/ntp.conf,noscan
+copy,/etc/systemd/timesyncd.conf,noscan
+echo,

--- a/manifests/linux/diagnostic-udev-common
+++ b/manifests/linux/diagnostic-udev-common
@@ -1,0 +1,6 @@
+echo,### Gathering Udev and Module Configuration ###
+copy,/etc/udev/rules.d/*.rules
+copy,/usr/lib/udev/rules.d/*.rules
+copy,/etc/modprobe.d/*.conf,noscan
+copy,/usr/lib/modprobe.d/*.conf,noscan
+echo,


### PR DESCRIPTION
PR: Modularize Linux Diagnostic Manifests
Summary
Splits Linux diagnostic collection into 80+ granular manifests for AI-driven selection, enabling targeted data collection based on issue type and distro.

Changes
New Manifests by Category

Probing: 5 manifests (ubuntu, redhat, suse, mariner, aks)
DHCP: 4 manifests per distro
Network Config: 4 manifests per distro + AKS networking
NetworkManager: 4 manifests per distro
DNS: common manifest
SSH: common manifest
Firewall: 4 manifests per distro
Azure Agent: 7 manifests (waagent, config, provisioning, extension-handler, proxyagent, identity, himds)
Azure Extensions: 9 manifests (handler, ama, lad, cse, vmaccess, diskencryption, backup, siterecovery, updatemanager)
Cloud-init/Blobfuse: 2 common manifests
System Config: fstab, pam, sudoers, boot, kernel, selinux, apparmor (common)
System Logs: syslog, authlog, kernlog, dmesg, journald, sosreport (per distro + common)
Packages: apt, yum, zypper, tdnf (per distro)
Kubernetes/AKS: 5 manifests (probing, provision, kubernetes, pods, networking)
HPC: common manifest
Naming Convention
diagnostic-<section>-<distro|common>

Documentation

10 area-specific docs in [linux](vscode-file://vscode-app/c:/Users/scotro/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[diagnostic-modular.md](vscode-file://vscode-app/c:/Users/scotro/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as master reference with links
PII risk tracking per manifest
No Breaking Changes

Original monolithic manifests preserved (diagnostic, normal, agents, etc.)